### PR TITLE
Fix: Dragging crew members to new roles throws an error

### DIFF
--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -340,7 +340,7 @@ export class ActorSheetStarfinderStarship extends ActorSheetStarfinder {
             data: actor.data
         };
 
-        if (this.actor.isToken) dragData.tokenId = actor.token.id;
+        if (this.actor.isToken) dragData.tokenId = actorId;
         event.dataTransfer.setData("text/plain", JSON.stringify(dragData));
     }
 


### PR DESCRIPTION
Dragging previously added crew members to a new role after reloading or restarting the application (for example when starting a new gaming session) throws the following error and you can't change roles.

`starship.js:355 Uncaught TypeError: Cannot read property 'id' of null
 at ActorSheetStarfinderStarship._onDragCrewStart (starship.js:355)`

For some reason the Actor **_token_** is being referenced (which is not always available) when the `actorId `is already available in a constant in the same function. This small change fixes that bug so that reassigning crew members always works.