### PR TITLE
Added support for child modifiers

### DIFF
--- a/src/less/items.less
+++ b/src/less/items.less
@@ -232,4 +232,154 @@
   .loot-header {
     margin-bottom: 10px;
   }
+
+  .inventory-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 5px;
+    overflow-y: auto;
+
+    // Inventory Item
+    .item {
+      line-height: 45px;
+      padding: 0 2px; // to align with the header border
+      border-bottom: 1px solid @colorFaint;
+      &:last-child { border-bottom: none; }
+
+      // Item Header Name
+      .item-name {
+        cursor: pointer;
+
+        &.modifier-name {
+          cursor: default;
+        }
+
+        .item-image {
+          flex: 0 0 45px;
+          background-size: 45px;
+          margin-right: 5px;
+        }
+
+        h4 {
+          margin: 0;
+        }
+
+        &:hover .item-image {
+          background-image: url("/icons/svg/d20-grey.svg") !important;
+        }
+
+        .item-image:hover {
+          background-image: url("/icons/svg/d20-black.svg") !important;
+        }
+
+        .item-action {
+          flex: 0 0 15%;
+  
+          .attack {
+            width: auto;
+            background: @sfrpgBlue;
+            color: #fff;
+            cursor: pointer;
+          }
+  
+          .damage {
+            width: auto;
+            background: @sfrpgRed;
+            color: #fff;
+            cursor: pointer;
+          }
+        }
+      }
+      
+      // Item Dropdown Properties
+      .item-properties {
+        margin-top: 3px;
+      }
+
+      // Charged
+      .item-recharge {
+        flex: 0 0 80px;
+        text-align: right;
+        font-size: 11px;
+        color: @colorTan;
+      }
+    }
+
+    // Inventory Header
+    .inventory-header {
+      margin: 2px 0;
+      padding: 0;
+      background: rgba(0, 0, 0, 0.05);
+      border: @borderGroove;
+      font-weight: bold;
+      line-height: 24px;
+
+      h3 {
+        margin: 0 -5px 0 0;
+        padding-left: 5px;
+        font-size: 13px;
+        font-weight: bold;
+      }
+
+      .item-controls a.modifier-create {
+        flex: 0 0 100%;
+      }
+    }
+
+    // Item Detail Sections
+    .item-detail {
+      &.modifier-effect-type { flex: 0 0 160px; }
+      &.modifier-value-affected { flex: 0 0 120px; }
+      &.modifier-type { flex: 0 0 95px; }
+
+      flex: 0 0 80px;
+      font-size: 12px;
+      color: @colorTan;
+      text-align: center;
+      border-right: 1px solid @colorFaint;
+      &:last-child { border-right: none; }      
+    }
+
+    .item-weight {
+      flex: 0 0 60px;
+      border-left: 1px solid @colorFaint;
+      border-right: 1px solid @colorFaint;
+    }
+
+    .item-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    // Item Control Buttons
+    .item-controls {
+      flex: 0 0 68px;
+      
+      .flexrow();
+      justify-content: flex-end;
+
+      a {
+        flex: 0 0 22px;
+        font-size: 10px;
+        text-align: center;
+        color: #666;
+
+        .item-create,
+        .modifier-create {
+          flex: 0 0 100%;
+        }
+      }
+    }
+
+    // Item Dropdown Summary
+    .item-summary {
+      flex: 0 0 100%;
+      font-size: 12px;
+      line-height: 16px;
+      padding: 0.25em 0.5em;
+      border-top: 1px solid @colorFaint;
+    }
+  }
+
 }

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -291,7 +291,8 @@ export class ActorSFRPG extends Actor {
                     }
                     break;
                 case "equipment":
-                    if (!ignoreEquipment && item.data.equipped) {
+                case "weapon":
+                        if (!ignoreEquipment && item.data.equipped) {
                         modifiersToConcat = item.data.modifiers;
                     }
                     break;

--- a/src/module/actor/sheet/character.js
+++ b/src/module/actor/sheet/character.js
@@ -125,19 +125,13 @@ export class ActorSheetSFRPGCharacter extends ActorSheetSFRPG {
         const modifiers = {
             conditions: { label: "SFRPG.ModifiersConditionsTabLabel", modifiers: [], dataset: { subtab: "conditions" }, isConditions: true },
             permanent: { label: "SFRPG.ModifiersPermanentTabLabel", modifiers: [], dataset: { subtab: "permanent" } },
-            temporary: { label: "SFRPG.ModifiersTemporaryTabLabel", modifiers: [], dataset: { subtab: "temporary" } },
-            item: { label: "SFRPG.ModifiersItemTabLabel", modifiers: [], dataset: { subtab: "item" } },
-            misc: { label: "SFRPG.ModifiersMiscTabLabel", modifiers: [], dataset: { subtab: "misc" } }
+            temporary: { label: "SFRPG.ModifiersTemporaryTabLabel", modifiers: [], dataset: { subtab: "temporary" } }
         };
 
         let [permanent, temporary, itemModifiers, conditions, misc] = data.data.modifiers.reduce((arr, modifier) => {
             if (modifier.subtab === "permanent") arr[0].push(modifier);
-            else if (modifier.subtab === "temporary") arr[1].push(modifier);
-            else if (modifier.subtab === "item") arr[2].push(modifier);
             else if (modifier.subtab === "conditions") arr[3].push(modifier);
-            // The miscellaneous group is kind of a catchall category. If a modifer isn't explicitly
-            // marked as belonging to a subtab, we'll just shove it in here.
-            else arr[4].push(modifier);
+            else arr[1].push(modifier); // Any unspecific categories go into temporary.
 
             return arr;
         }, [[], [], [], [], []]);
@@ -145,8 +139,6 @@ export class ActorSheetSFRPGCharacter extends ActorSheetSFRPG {
         modifiers.conditions.modifiers = conditions;
         modifiers.permanent.modifiers = permanent;
         modifiers.temporary.modifiers = temporary;
-        modifiers.item.modifiers = itemModifiers;
-        modifiers.misc.modifiers = misc;
 
         data.modifiers = Object.values(modifiers);
     }

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1,4 +1,7 @@
 import { DiceSFRPG } from "../dice.js";
+import { SFRPGModifierType, SFRPGModifierTypes, SFRPGEffectType } from "../modifiers/types.js";
+import SFRPGModifier from "../modifiers/modifier.js";
+import SFRPGModifierApplication from "../apps/modifier-app.js";
 
 export class ItemSFRPG extends Item {
 
@@ -122,6 +125,24 @@ export class ItemSFRPG extends Item {
 
         // Assign labels and return the Item
         this.labels = labels;
+    }
+
+    /**
+     * Check to ensure that this item has a modifiers data object set, if not then set it. 
+     * These will always be needed from hence forth, so we'll just make sure that they always exist.
+     * 
+     * @param {Object}      data The item data to check against.
+     * @param {String|Null} prop A specific property name to check.
+     * 
+     * @returns {Object}         The modified data object with the modifiers data object added.
+     */
+    _ensureHasModifiers(data, prop = null) {
+        if (!hasProperty(data, "modifiers")) {
+            console.log(`SFRPG | ${this.name} does not have the modifiers data object, attempting to create them...`);
+            data.modifiers = [];
+        }
+
+        return data;
     }
 
     /* -------------------------------------------- */
@@ -903,5 +924,82 @@ export class ItemSFRPG extends Item {
         if (controlled.length === 0) return character || null;
         if (controlled.length === 1) return controlled[0].actor;
         else throw new Error(`You must designate a specific Token as the roll target`);
+    }
+    
+    /**
+     * Add a modifier to this actor.
+     * 
+     * @param {Object}        data               The data needed to create the modifier
+     * @param {String}        data.name          The name of this modifier. Used to identify the modfier.
+     * @param {Number|String} data.modifier      The modifier value.
+     * @param {String}        data.type          The modifiers type. Used to determine stacking.
+     * @param {String}        data.modifierType  Used to determine if this modifier is a constant value (+2) or a Roll formula (1d4).
+     * @param {String}        data.effectType    The category of things that might be effected by this modifier.
+     * @param {String}        data.subtab        What subtab should this modifier show under on the character sheet.
+     * @param {String}        data.valueAffected The specific value being modified.
+     * @param {Boolean}       data.enabled       Is this modifier activated or not.
+     * @param {String}        data.source        Where did this modifier come from? An item, ability or something else?
+     * @param {String}        data.notes         Any notes or comments about the modifier.
+     * @param {String}        data.condition     The condition, if any, that this modifier is associated with.
+     * @param {String|null}   data.id            Override the randomly generated id with this.
+     */
+    async addModifier({
+        name = "", 
+        modifier = 0, 
+        type = SFRPGModifierTypes.UNTYPED, 
+        modifierType = SFRPGModifierType.CONSTANT, 
+        effectType = SFRPGEffectType.SKILL,
+        subtab = "misc",
+        valueAffected = "", 
+        enabled = true, 
+        source = "", 
+        notes = "",
+        condition = "",
+        id = null
+    } = {}) {
+        const data = this._ensureHasModifiers(duplicate(this.data.data));
+        const modifiers = data.modifiers;
+
+        modifiers.push(new SFRPGModifier({
+            name,
+            modifier,
+            type,
+            modifierType,
+            effectType,
+            valueAffected,
+            enabled,
+            source,
+            notes,
+            subtab,
+            condition,
+            id
+        }));
+
+        console.log("Adding a modifier to the item");
+
+        await this.update({["data.modifiers"]: modifiers});
+    }
+
+    /**
+     * Delete a modifier for this Actor.
+     * 
+     * @param {String} id The id for the modifier to delete
+     */
+    async deleteModifier(id) {
+        const modifiers = this.data.data.modifiers.filter(mod => mod._id !== id);
+        
+        await this.update({"data.modifiers": modifiers});
+    }
+
+    /**
+     * Edit a modifier for an Actor.
+     * 
+     * @param {String} id The id for the modifier to edit
+     */
+    editModifier(id) {
+        const modifiers = duplicate(this.data.data.modifiers);
+        const modifier = modifiers.find(mod => mod._id === id);
+
+        new SFRPGModifierApplication(modifier, this).render(true);
     }
 }

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -23,7 +23,7 @@ export class ItemSheetSFRPG extends ItemSheet {
   
       static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-        width: 560,
+        width: 715,
         height: 600,
         classes: ["sfrpg", "sheet", "item"],
         resizable: true,
@@ -81,6 +81,8 @@ export class ItemSheetSFRPG extends ItemSheet {
           save.dc = 10 + data.item.data.level + actor.data.data.abilities[abl].mod;
         }
       }
+
+      data.modifiers = this.item.data.data.modifiers;
       
       return data;
     }
@@ -218,6 +220,11 @@ export class ItemSheetSFRPG extends ItemSheet {
       // Modify damage formula
       html.find(".damage-control").click(this._onDamageControl.bind(this));
       html.find(".ability-adjustments-control").click(this._onAbilityAdjustmentsControl.bind(this));
+
+      html.find('.modifier-create').click(this._onModifierCreate.bind(this));
+      html.find('.modifier-edit').click(this._onModifierEdit.bind(this));
+      html.find('.modifier-delete').click(this._onModifierDelete.bind(this));
+      html.find('.modifier-toggle').click(this._onToggleModifierEnabled.bind(this));
     }
   
     /* -------------------------------------------- */
@@ -285,4 +292,62 @@ export class ItemSheetSFRPG extends ItemSheet {
         return this.item.update({"data.critical.parts": criticalDamage.parts});
       }
     }
+    
+    /**
+    * Add a modifer to this item.
+    * 
+    * @param {Event} event The originating click event
+    */
+   _onModifierCreate(event) {
+       event.preventDefault();
+       const target = $(event.currentTarget);
+
+       this.item.addModifier({
+           name: "New Modifier"
+       });
+   }
+
+   /**
+    * Delete a modifier from the item.
+    * 
+    * @param {Event} event The originating click event
+    */
+   async _onModifierDelete(event) {
+       event.preventDefault();
+       const target = $(event.currentTarget);
+       const modifierId = target.closest('.item.modifier').data('modifierId');
+       
+       await this.item.deleteModifier(modifierId);
+   }
+
+   /**
+    * Edit a modifier for an item.
+    * 
+    * @param {Event} event The orginating click event
+    */
+   _onModifierEdit(event) {
+       event.preventDefault();
+
+       const target = $(event.currentTarget);
+       const modifierId = target.closest('.item.modifier').data('modifierId');
+
+       this.item.editModifier(modifierId);
+   }
+
+   /**
+    * Toggle a modifier to be enabled or disabled.
+    * 
+    * @param {Event} event The originating click event
+    */
+   async _onToggleModifierEnabled(event) {
+       event.preventDefault();
+       const target = $(event.currentTarget);
+       const modifierId = target.closest('.item.modifier').data('modifierId');
+
+       const modifiers = duplicate(this.item.data.data.modifiers);
+       const modifier = modifiers.find(mod => mod._id === modifierId);
+       modifier.enabled = !modifier.enabled;
+
+       await this.item.update({'data.modifiers': modifiers});
+   }
   }

--- a/src/module/templates.js
+++ b/src/module/templates.js
@@ -18,7 +18,8 @@ export const preloadHandlebarsTemplates = async function () {
         "systems/sfrpg/templates/items/parts/item-action.html",
         "systems/sfrpg/templates/items/parts/item-activation.html",
         "systems/sfrpg/templates/items/parts/item-description.html",
-        "systems/sfrpg/templates/items/parts/item-capacity.html"
+        "systems/sfrpg/templates/items/parts/item-capacity.html",
+        "systems/sfrpg/templates/items/parts/item-modifiers.html"
     ];
 
     return loadTemplates(templatePaths);

--- a/src/templates/items/archetypes.html
+++ b/src/templates/items/archetypes.html
@@ -29,6 +29,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{ localize "SFRPG.Description" }}</a>
         <a class="item" data-tab="details">{{ localize "SFRPG.Details" }}</a>
+        <a class="item" data-tab="modifiers">{{ localize "SFRPG.Modifiers" }}</a>
     </nav>
 
     {{!-- Item Sheet Body --}}
@@ -46,5 +47,8 @@
             {{!-- Granted alternate abilities --}}
             <p class="notification warning">Coming soon!</p>
         </div>
+
+        {{!-- Modifiers Tab --}}
+        {{> "systems/sfrpg/templates/items/parts/item-modifiers.html"}}
     </section>
 </form>

--- a/src/templates/items/augmentation.html
+++ b/src/templates/items/augmentation.html
@@ -26,6 +26,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{ localize "SFRPG.Description" }}</a>
         <a class="item" data-tab="details">{{ localize "SFRPG.Details" }}</a>
+        <a class="item" data-tab="modifiers">{{ localize "SFRPG.Modifiers" }}</a>
     </nav>
 
     {{!-- Item Sheet Body --}}
@@ -63,5 +64,8 @@
                 </div>
             </div>
         </div>
+
+        {{!-- Modifiers Tab --}}
+        {{> "systems/sfrpg/templates/items/parts/item-modifiers.html"}}
     </section>
 </form>

--- a/src/templates/items/class.html
+++ b/src/templates/items/class.html
@@ -26,6 +26,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{ localize "SFRPG.Description" }}</a>
         <a class="item" data-tab="details">{{ localize "SFRPG.Details" }}</a>
+        <a class="item" data-tab="modifiers">{{ localize "SFRPG.Modifiers" }}</a>
     </nav>
 
     {{!-- Item Sheet Body --}}
@@ -165,5 +166,8 @@
                 {{/each}}
             </div>
         </div>
+
+        {{!-- Modifiers Tab --}}
+        {{> "systems/sfrpg/templates/items/parts/item-modifiers.html"}}
     </section>
 </form>

--- a/src/templates/items/equipment.html
+++ b/src/templates/items/equipment.html
@@ -29,6 +29,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{ localize "SFRPG.Description" }}</a>
         <a class="item" data-tab="details">{{ localize "SFRPG.Details" }}</a>
+        <a class="item" data-tab="modifiers">{{ localize "SFRPG.Modifiers" }}</a>
     </nav>
 
     {{!-- Item Sheet Body --}}
@@ -179,5 +180,9 @@
             {{!-- Item Action Template --}}
             {{> "systems/sfrpg/templates/items/parts/item-action.html"}}
         </div>
+
+        {{!-- Modifiers Tab --}}
+        {{> "systems/sfrpg/templates/items/parts/item-modifiers.html"}}
+
     </section>
 </form>

--- a/src/templates/items/feat.html
+++ b/src/templates/items/feat.html
@@ -32,6 +32,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{ localize "SFRPG.Description" }}</a>
         <a class="item" data-tab="details">{{ localize "SFRPG.Details" }}</a>
+        <a class="item" data-tab="modifiers">{{ localize "SFRPG.Modifiers" }}</a>
     </nav>
 
     {{!-- Item Sheet Body --}}
@@ -69,5 +70,8 @@
             {{!-- Item Action Template --}}
             {{> "systems/sfrpg/templates/items/parts/item-action.html"}}
         </div>
+
+        {{!-- Modifiers Tab --}}
+        {{> "systems/sfrpg/templates/items/parts/item-modifiers.html"}}
     </section>
 </form>

--- a/src/templates/items/parts/item-modifiers.html
+++ b/src/templates/items/parts/item-modifiers.html
@@ -1,0 +1,79 @@
+<div class="tab flexrow active" data-group="primary" data-tab="modifiers">
+
+    <ol class="inventory-list">
+        <li class="item flexrow inventory-header modifiers-header">
+            <div class="item-name modifier-name flexrow">
+                <h3>{{localize "SFRPG.ModifierNameLabel"}}</h3>
+            </div>
+
+            <div class="item-detail modifier-mod">{{localize "SFRPG.ModifierTitle"}}</div>
+            <div class="item-detail modifier-type">{{localize "SFRPG.ModifierTypeLabel"}}</div>
+            <div class="item-detail modifier-effect-type">{{localize "SFRPG.ModifierEffectTypeHeaderLabel"}}</div>
+            <div class="item-detail modifier-value-affected">{{localize "SFRPG.ModifierValueAffectedHeaderLabel"}}</div>
+            {{#if owner}}
+            <div class="item-controls">
+                <a class="item-control modifier-create" {{#each section.dataset as |v k|}}data-{{k}}="{{v}}"{{/each}} title="Add Modifier">
+                    <i class="fas fa-plus"></i> {{localize "SFRPG.AddLabel"}}
+                </a>
+            </div>
+            {{/if}}
+        </li>
+
+        <ol class="modifier-list item-list">
+            {{#each modifiers as |modifier mid|}}
+            <li class="item modifier flexrow" data-tippy-content="<strong>{{modifier.name}}</strong><br>{{#if modifier.enabled}}Enabled{{else}}Disabled{{/if}}{{#if modifier.notes}}<br><br>Notes<hr>{{modifier.notes}}{{/if}}" data-modifier-id="{{modifier._id}}">
+                <div class="item-name modifier-name flexrow">
+                    <h4>{{~modifier.name~}}</h4>
+                </div>
+
+                <div class="item-detail modifier-mod">
+                    {{#if (eq modifier.modifierType "constant")}}
+                    {{numberFormat modifier.modifier decimals=0 sign=true}}
+                    {{else}}
+                    {{~modifier.modifier~}}
+                    {{/if}}
+                </div>
+                <div class="item-detail modifier-type">
+                    {{lookup ../config.modifierTypes modifier.type}}
+                </div>
+                <div class="item-detail modifier-effect-type">
+                    {{lookup ../config.modifierEffectTypes modifier.effectType}}
+                </div>
+                <div class="item-detail modifier-value-affected">
+                {{#if (eq modifier.effectType "ac")}}
+                    {{lookup ../config.modifierArmorClassAffectedValues modifier.valueAffected}}
+                {{else if (eq modifier.effectType "acp")}}
+                    {{lookup ../config.acpEffectingArmorType modifier.valueAffected}}
+                {{else if (eq modifier.effectType "ability-skills")}}
+                    {{lookup ../config.abilities modifier.valueAffected}}
+                {{else if (eq modifier.effectType "ability-check")}}
+                    {{lookup ../config.abilities modifier.valueAffected}}
+                {{else if (eq modifier.effectType "ability-score")}}
+                    {{lookup ../config.abilities modifier.valueAffected}}
+                {{else if (eq modifier.effectType "skill")}}
+                    {{lookup ../config.skills modifier.valueAffected}}
+                {{else if (eq modifier.effectType "save")}}
+                    {{#if (eq modifier.valueAffected "highest")}}
+                        {{localize "SFRPG.ModifierSaveHighest"}}
+                    {{else if (eq modifier.valueAffected "lowest")}}
+                        {{localize "SFRPG.ModifierSaveLowest"}}
+                    {{else}}
+                        {{lookup ../config.saves modifier.valueAffected}}
+                    {{/if}}                        
+                {{else}}
+                {{!-- Nothing --}}
+                {{/if}}
+                </div>
+                {{#if ../owner}}
+                <div class="item-controls">
+                    <a class="item-control modifier-toggle" data-tippy-content="Toggle Modifier">{{#if modifier.enabled}}<i class="far fa-check-square">{{else}}<i class="far fa-square"></i>{{/if}}</i></a>
+                    <a class="item-control modifier-edit" data-tippy-content="Edit Modifier"><i class="fas fa-edit"></i></a>
+                    <a class="item-control modifier-delete" data-tippy-content="Delete Modifier"><i class="fas fa-trash"></i></a>
+                </div>
+                {{/if}}
+            </li>
+            {{/each}}
+        </ol>
+    </ol>
+
+</div>

--- a/src/templates/items/race.html
+++ b/src/templates/items/race.html
@@ -32,6 +32,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{ localize "SFRPG.Description" }}</a>
         <a class="item" data-tab="details">{{ localize "SFRPG.Details" }}</a>
+        <a class="item" data-tab="modifiers">{{ localize "SFRPG.Modifiers" }}</a>
     </nav>
 
     {{!-- Item Sheet Body --}}
@@ -90,5 +91,8 @@
                 {{/each}}
             </ol>
         </div>
+
+        {{!-- Modifiers Tab --}}
+        {{> "systems/sfrpg/templates/items/parts/item-modifiers.html"}}
     </section>
 </form>

--- a/src/templates/items/theme.html
+++ b/src/templates/items/theme.html
@@ -26,6 +26,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{ localize "SFRPG.Description" }}</a>
         <a class="item" data-tab="details">{{ localize "SFRPG.Details" }}</a>
+        <a class="item" data-tab="modifiers">{{ localize "SFRPG.Modifiers" }}</a>
     </nav>
 
     {{!-- Item Sheet Body --}}
@@ -65,5 +66,8 @@
                 </select>
             </div>
         </div>
+
+        {{!-- Modifiers Tab --}}
+        {{> "systems/sfrpg/templates/items/parts/item-modifiers.html"}}
     </section>
 </form>

--- a/src/templates/items/weapon.html
+++ b/src/templates/items/weapon.html
@@ -29,6 +29,7 @@
     <nav class="sheet-navigation tabs" data-group="primary">
         <a class="item active" data-tab="description">{{ localize "SFRPG.Description" }}</a>
         <a class="item" data-tab="details">{{ localize "SFRPG.Details" }}</a>
+        <a class="item" data-tab="modifiers">{{ localize "SFRPG.Modifiers" }}</a>
     </nav>
 
     {{!-- Item Sheet Body --}}
@@ -93,6 +94,9 @@
             <h3 class="form-header">{{ localize "SFRPG.CapacityUsage" }}</h3>
             {{> "systems/sfrpg/templates/items/parts/item-capacity.html"}}
         </div>
+
+        {{!-- Modifiers Tab --}}
+        {{> "systems/sfrpg/templates/items/parts/item-modifiers.html"}}
         
     </section>
 </form>


### PR DESCRIPTION
Updated modifiers system for player characters:
* Added support for child modifiers from items.
* Added modifiers to the sheets of archetypes, augmentations, classes, equipment, feats, races, themes, and weapons.
* Added passing of child modifiers to closures.
* Removed Item and Misc categories from character modifiers sheet.
