### PR TITLE
QoL: Easy Equipping

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -186,6 +186,9 @@ export class ActorSheetSFRPG extends ActorSheet {
 
         // Item Recharging
         html.find('.item .item-recharge').click(event => this._onItemRecharge(event));
+
+        // Item Equipping
+        html.find('.item .item-equip').click(event => this._onItemEquippedChange(event));
     }
 
     /** @override */
@@ -336,6 +339,20 @@ export class ActorSheetSFRPG extends ActorSheet {
         const itemId = event.currentTarget.closest('.item').dataset.itemId;
         const item = this.actor.getOwnedItem(itemId);
         return item.rollRecharge();
+    }
+
+    /**
+     * Handle toggling the equipped state of an item.
+     * @param {Event} event The originating click event
+     */
+    _onItemEquippedChange(event) {
+        event.preventDefault();
+        const itemId = event.currentTarget.closest('.item').dataset.itemId;
+        const item = this.actor.getOwnedItem(itemId);
+
+        item.update({
+            ["data.equipped"]: !item.data.data.equipped
+        });
     }
 
     /**

--- a/src/templates/actors/parts/actor-inventory.html
+++ b/src/templates/actors/parts/actor-inventory.html
@@ -63,8 +63,13 @@
             </div>
 
             <div class="item-detail item-equipped">
-            {{#if item.data.equipped }} {{localize "SFRPG.InventoryEquipped"}}
-            {{/if}}
+                {{#if (or (eq item.type "weapon") (eq item.type "equipment"))}}
+                <label class="checkbox">
+                    <input type="checkbox" class="item-equip" name="item.data.equipped" {{checked item.data.equipped}}/>{{localize "SFRPG.InventoryEquipped"}}
+                </label>
+                {{else}}
+                N/A
+                {{/if}}
             </div>
             {{/if}}
 

--- a/src/templates/actors/parts/actor-inventory.html
+++ b/src/templates/actors/parts/actor-inventory.html
@@ -65,7 +65,7 @@
             <div class="item-detail item-equipped">
                 {{#if (or (eq item.type "weapon") (eq item.type "equipment"))}}
                 <label class="checkbox">
-                    <input type="checkbox" class="item-equip" name="item.data.equipped" {{checked item.data.equipped}}/>{{localize "SFRPG.InventoryEquipped"}}
+                    <input type="checkbox" class="item-equip" name="item.data.equipped" {{checked item.data.equipped}}/>
                 </label>
                 {{else}}
                 N/A


### PR DESCRIPTION
A minor QoL thing that is helpful for many players, this adds a checkbox to the inventory screen for weapons and equipment. This will also affect closures that respond to the item modifiers, once the child modifiers pull request goes through.