### PR TITLE
Invalid text for swift action

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -271,7 +271,7 @@
     "SFRPG.AbilityActivationTypesNone": "None",
     "SFRPG.AbilityActivationTypesStandard": "S. Action",
     "SFRPG.AbilityActivationTypesMove": "M. Action",
-    "SFRPG.AbilityActivationTypesSwift": "Swfit Action",
+    "SFRPG.AbilityActivationTypesSwift": "Swift Action",
     "SFRPG.AbilityActivationTypesFull": "Full Action",
     "SFRPG.AbilityActivationTypesReaction": "Reaction",
     "SFRPG.AbilityActivationTypesOther": "Other Actions",


### PR DESCRIPTION
It says swfit action, should say swift action. Caught by cmd.