### PR TITLE
Shields update

### DIFF
--- a/src/items/equipment/dousing_shield_advanced.json
+++ b/src/items/equipment/dousing_shield_advanced.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 51,
+        "max": "51"
       },
       "hardness": {
-        "value": ""
+        "value": "29"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/dousing_shield_basic.json
+++ b/src/items/equipment/dousing_shield_basic.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 21,
+        "max": "21"
       },
       "hardness": {
-        "value": ""
+        "value": "9"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/dousing_shield_elite.json
+++ b/src/items/equipment/dousing_shield_elite.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 96,
+        "max": "96"
       },
       "hardness": {
-        "value": ""
+        "value": "39"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/dousing_shield_field.json
+++ b/src/items/equipment/dousing_shield_field.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 36,
+        "max": "36"
       },
       "hardness": {
-        "value": ""
+        "value": "19"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/gravity_shield_advanced.json
+++ b/src/items/equipment/gravity_shield_advanced.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 57,
+        "max": "57"
       },
       "hardness": {
-        "value": ""
+        "value": "33"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/gravity_shield_basic.json
+++ b/src/items/equipment/gravity_shield_basic.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 27,
+        "max": "27"
       },
       "hardness": {
-        "value": ""
+        "value": "13"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/gravity_shield_elite.json
+++ b/src/items/equipment/gravity_shield_elite.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 102,
+        "max": "102"
       },
       "hardness": {
-        "value": ""
+        "value": "43"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/gravity_shield_field.json
+++ b/src/items/equipment/gravity_shield_field.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 42,
+        "max": "42"
       },
       "hardness": {
-        "value": ""
+        "value": "23"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/irising_shield_advanced.json
+++ b/src/items/equipment/irising_shield_advanced.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 48,
+        "max": "48"
       },
       "hardness": {
-        "value": ""
+        "value": "27"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/irising_shield_basic.json
+++ b/src/items/equipment/irising_shield_basic.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 21,
+        "max": "21"
       },
       "hardness": {
-        "value": ""
+        "value": "9"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/irising_shield_elite.json
+++ b/src/items/equipment/irising_shield_elite.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 93,
+        "max": "93"
       },
       "hardness": {
-        "value": ""
+        "value": "37"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/irising_shield_field.json
+++ b/src/items/equipment/irising_shield_field.json
@@ -24,14 +24,14 @@
         "mod": ""
       },
       "hp": {
-        "value": 6,
-        "max": ""
+        "value": 33,
+        "max": "33"
       },
       "hardness": {
-        "value": ""
+        "value": "17"
       },
       "ac": {
-        "value": ""
+        "value": "10"
       }
     },
     "activation": {

--- a/src/items/equipment/knight’s_shield_advanced.json
+++ b/src/items/equipment/knight’s_shield_advanced.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 54,
+        "max": "54"
+      },
+      "hardness": {
+        "value": "31"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/knight’s_shield_basic.json
+++ b/src/items/equipment/knight’s_shield_basic.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 24,
+        "max": "24"
+      },
+      "hardness": {
+        "value": "11"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/knight’s_shield_elite.json
+++ b/src/items/equipment/knight’s_shield_elite.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 99,
+        "max": "99"
+      },
+      "hardness": {
+        "value": "41"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/knight’s_shield_field.json
+++ b/src/items/equipment/knight’s_shield_field.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 39,
+        "max": "39"
+      },
+      "hardness": {
+        "value": "21"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/riot_shield_advanced.json
+++ b/src/items/equipment/riot_shield_advanced.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 45,
+        "max": "45"
+      },
+      "hardness": {
+        "value": "25"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/riot_shield_basic.json
+++ b/src/items/equipment/riot_shield_basic.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 18,
+        "max": "18"
+      },
+      "hardness": {
+        "value": "7"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/riot_shield_elite.json
+++ b/src/items/equipment/riot_shield_elite.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 90,
+        "max": "90"
+      },
+      "hardness": {
+        "value": "35"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/riot_shield_field.json
+++ b/src/items/equipment/riot_shield_field.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 30,
+        "max": "30"
+      },
+      "hardness": {
+        "value": "15"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/tactical_shield_advanced.json
+++ b/src/items/equipment/tactical_shield_advanced.json
@@ -75,7 +75,7 @@
     "acp": 0,
     "bonus": {
       "wielded": 1,
-      "aligned": 1
+      "aligned": 2
     },
     "proficient": false,
     "container": {

--- a/src/items/equipment/tactical_shield_advanced.json
+++ b/src/items/equipment/tactical_shield_advanced.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 45,
+        "max": "45"
+      },
+      "hardness": {
+        "value": "25"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/tactical_shield_basic.json
+++ b/src/items/equipment/tactical_shield_basic.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 18,
+        "max": "18"
+      },
+      "hardness": {
+        "value": "7"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/tactical_shield_elite.json
+++ b/src/items/equipment/tactical_shield_elite.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 90,
+        "max": "90"
+      },
+      "hardness": {
+        "value": "35"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/tactical_shield_field.json
+++ b/src/items/equipment/tactical_shield_field.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 30,
+        "max": "30"
+      },
+      "hardness": {
+        "value": "15"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/items/equipment/tactical_shield_paragon.json
+++ b/src/items/equipment/tactical_shield_paragon.json
@@ -21,7 +21,22 @@
     "equipped": false,
     "identified": true,
     "attributes": {
-      "sturdy": true
+      "sturdy": true,
+      "customBuilt": false,
+      "size": "medium",
+      "dex": {
+        "mod": ""
+      },
+      "hp": {
+        "value": 105,
+        "max": "105"
+      },
+      "hardness": {
+        "value": "45"
+      },
+      "ac": {
+        "value": "10"
+      }
     },
     "activation": {
       "type": "",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -98,7 +98,9 @@
         "ACTooltipBase": "Rüstungsklasse: {base}",
         "ACTooltipBonus": "{type} Bonus: {mod} ({source})",
         "ACTooltipMaxDex": "Geschicklichkeitsmodifikator: {maxDex} (armor max dex: {armorMax})",
-        "ACTooltipNotProficientMod": "Malus für fehlenden Umgang mit Rüstungsart: {profMod}",
+        "ACTooltipNotProficientMod": "Penalty for armor non-proficiency: {profMod}",
+        "ACTooltipNotProficientShield": "Penalty for shield non-proficiency: {profMod}",
+        "ACTooltipShieldACMod": "Shield Modifier: {shield} ({name})",
         "ActorSheet": {
             "Attributes": {
                 "Skills": {

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -97,7 +97,7 @@
         "ACTooltipArmorACMod": "Rüstungsmodifikator: {armor} ({name})",
         "ACTooltipBase": "Rüstungsklasse: {base}",
         "ACTooltipBonus": "{type} Bonus: {mod} ({source})",
-        "ACTooltipMaxDex": "Geschicklichkeitsmodifikator: {maxDex} (armor max dex: {armorMax})",
+        "ACTooltipMaxDex": "Geschicklichkeitsmodifikator: {maxDex} (max armor: {armorMax}, max shield: {shieldMax})",
         "ACTooltipNotProficientMod": "Penalty for armor non-proficiency: {profMod}",
         "ACTooltipNotProficientShield": "Penalty for shield non-proficiency: {profMod}",
         "ACTooltipShieldACMod": "Shield Modifier: {shield} ({name})",
@@ -821,6 +821,7 @@
             "Identified"     : "Identifiziert",
             "MaxDex"         : "Max. Geschicklichkeitsmodifikator",
             "Proficient"     : "Im Umgang geübt",
+            "NotProficient"  : "Not Proficient",
             "Unlimited"      : "Unbegrenzt",
             "Action": {
                 "ActionType"            : "Aktionstyp",
@@ -939,16 +940,24 @@
                 "Details": "Magic Item Details"
             },
             "Shield": {
-                "Action" : "Schildaktion",
-                "Aligned": "Ausgerichtet",
-                "Bonus"  : "Schildbonus",
-                "Details": "Schilddetails",
-                "Wielded": "Angelegt"
+                "Action"     : "Schildaktion",
+                "AcMaxDex"   : "Max dex bonus: {maxDex}",
+                "ACP"        : "ACP: {acp}",
+                "Aligned"    : "Ausgerichtet",
+                "ArmorCheck" : "Armor check penalty: {acp}",
+                "Bonus"      : "Schildbonus",
+                "Bonuses"    : "Wielded bonus: {wielded} / Aligned bonus: {aligned}",
+                "Details"    : "Schilddetails",
+                "Dex"        : "Dex: {dex}",
+                "Shield"     : "Shield",
+                "ShieldBonus": "Shield: {wielded} / {aligned}",
+                "Wielded"    : "Angelegt"
             },
             "ShipWeapon": {
                 "ItemType"    : "Raumschiffwaffe",
                 "Source"      : "Quelle",
                 "Mounted"     : "Montiert",
+                "NotMounted"  : "Not Mounted",
                 "Activated"   : "Aktiviert",
                 "WeaponArc"   : "Schussbereich der Waffe",
                 "WeaponClass" : "Waffenklassifikation",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -97,7 +97,7 @@
         "ACTooltipArmorACMod": "Armor Modifier: {armor} ({name})",
         "ACTooltipBase": "Base Armor Class: {base}",
         "ACTooltipBonus": "{type} Bonus: {mod} ({source})",
-        "ACTooltipMaxDex": "Dexterity Modifier: {maxDex} (armor max dex: {armorMax})",
+        "ACTooltipMaxDex": "Dexterity Modifier: {maxDex} (max armor: {armorMax}, max shield: {shieldMax})",
         "ACTooltipNotProficientMod": "Penalty for armor non-proficiency: {profMod}",
         "ACTooltipNotProficientShield": "Penalty for shield non-proficiency: {profMod}",
         "ACTooltipShieldACMod": "Shield Modifier: {shield} ({name})",
@@ -821,6 +821,7 @@
             "Identified"     : "Identified",
             "MaxDex"         : "Max. Dexterity Modifier",
             "Proficient"     : "Proficient",
+            "NotProficient"  : "Not Proficient",
             "Unlimited"      : "Unlimited",
             "Action": {
                 "ActionType"            : "Action Type",
@@ -939,16 +940,24 @@
                 "Details": "Magic Item Details"
             },
             "Shield": {
-                "Action" : "Shield Action",
-                "Aligned": "Aligned",
-                "Bonus"  : "Shield Bonus",
-                "Details": "Shield Details",
-                "Wielded": "Wielded"
+                "Action"     : "Shield Action",
+                "AcMaxDex"   : "Max dex bonus: {maxDex}",
+                "ACP"        : "ACP: {acp}",
+                "Aligned"    : "Aligned",
+                "ArmorCheck" : "Armor check penalty: {acp}",
+                "Bonus"      : "Shield Bonus",
+                "Bonuses"    : "Wielded bonus: {wielded} / Aligned bonus: {aligned}",
+                "Details"    : "Shield Details",
+                "Dex"        : "Dex: {dex}",
+                "Shield"     : "Shield",
+                "ShieldBonus": "Shield: {wielded} / {aligned}",
+                "Wielded"    : "Wielded"
             },
             "ShipWeapon": {
                 "ItemType"    : "Starship Weapon",
                 "Source"      : "Source",
                 "Mounted"     : "Mounted",
+                "NotMounted"  : "Not Mounted",
                 "Activated"   : "Activated",
                 "WeaponArc"   : "Weapon Arc",
                 "WeaponClass" : "Weapon Class",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -98,7 +98,9 @@
         "ACTooltipBase": "Base Armor Class: {base}",
         "ACTooltipBonus": "{type} Bonus: {mod} ({source})",
         "ACTooltipMaxDex": "Dexterity Modifier: {maxDex} (armor max dex: {armorMax})",
-        "ACTooltipNotProficientMod": "Penalty for non-proficiency: {profMod}",
+        "ACTooltipNotProficientMod": "Penalty for armor non-proficiency: {profMod}",
+        "ACTooltipNotProficientShield": "Penalty for shield non-proficiency: {profMod}",
+        "ACTooltipShieldACMod": "Shield Modifier: {shield} ({name})",
         "ActorSheet": {
             "Attributes": {
                 "Skills": {

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -97,7 +97,7 @@
         "ACTooltipArmorACMod": "Modificateur d'armure: {armor} ({name})",
         "ACTooltipBase": "Classe d'Armure de base: {base}",
         "ACTooltipBonus": "{type} Bonus: {mod} ({source})",
-        "ACTooltipMaxDex": "Modificateur de dextérité: {maxDex} (armure max dex: {armorMax})",
+        "ACTooltipMaxDex": "Modificateur de dextérité: {maxDex} (armure max: {armorMax}, shield max: {shieldMax})",
         "ACTooltipNotProficientMod": "Penalty for armor non-proficiency: {profMod}",
         "ACTooltipNotProficientShield": "Penalty for shield non-proficiency: {profMod}",
         "ACTooltipShieldACMod": "Shield Modifier: {shield} ({name})",
@@ -821,6 +821,7 @@
             "Identified"     : "Identified",
             "MaxDex"         : "Max. Dexterity Modifier",
             "Proficient"     : "Proficient",
+            "NotProficient"  : "Not Proficient",
             "Unlimited"      : "Unlimited",
             "Action": {
                 "ActionType"            : "Action Type",
@@ -939,16 +940,24 @@
                 "Details": "Magic Item Details"
             },
             "Shield": {
-                "Action" : "Shield Action",
-                "Aligned": "Aligned",
-                "Bonus"  : "Shield Bonus",
-                "Details": "Shield Details",
-                "Wielded": "Wielded"
+                "Action"     : "Shield Action",
+                "AcMaxDex"   : "Max dex bonus: {maxDex}",
+                "ACP"        : "ACP: {acp}",
+                "Aligned"    : "Aligned",
+                "ArmorCheck" : "Armor check penalty: {acp}",
+                "Bonus"      : "Shield Bonus",
+                "Bonuses"    : "Wielded bonus: {wielded} / Aligned bonus: {aligned}",
+                "Details"    : "Shield Details",
+                "Dex"        : "Dex: {dex}",
+                "Shield"     : "Shield",
+                "ShieldBonus": "Shield: {wielded} / {aligned}",
+                "Wielded"    : "Wielded"
             },
             "ShipWeapon": {
                 "ItemType"    :"Starship Weapon",
                 "Source"      : "Source",
                 "Mounted"     : "Mounted",
+                "NotMounted"  : "Not Mounted",
                 "Activated"   : "Activated",
                 "WeaponArc"   : "Weapon Arc",
                 "WeaponClass" : "Weapon Class",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -98,7 +98,9 @@
         "ACTooltipBase": "Classe d'Armure de base: {base}",
         "ACTooltipBonus": "{type} Bonus: {mod} ({source})",
         "ACTooltipMaxDex": "Modificateur de dextérité: {maxDex} (armure max dex: {armorMax})",
-        "ACTooltipNotProficientMod": "Pénalité pour non-maniement: {profMod}",
+        "ACTooltipNotProficientMod": "Penalty for armor non-proficiency: {profMod}",
+        "ACTooltipNotProficientShield": "Penalty for shield non-proficiency: {profMod}",
+        "ACTooltipShieldACMod": "Shield Modifier: {shield} ({name})",
         "ActorSheet": {
             "Attributes": {
                 "Skills": {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -97,7 +97,7 @@
         "ACTooltipArmorACMod": "ＡＣ修正値: {armor} ({name})",
         "ACTooltipBase": "基本ＡＣ: {base}",
         "ACTooltipBonus": "{type} ボーナス: {mod} ({source})",
-        "ACTooltipMaxDex": "敏捷力修正値: {maxDex} (armor max dex: {armorMax})",
+        "ACTooltipMaxDex": "敏捷力修正値: {maxDex} (max armor: {armorMax}, max shield: {shieldMax})",
         "ACTooltipNotProficientMod": "Penalty for armor non-proficiency: {profMod}",
         "ACTooltipNotProficientShield": "Penalty for shield non-proficiency: {profMod}",
         "ACTooltipShieldACMod": "Shield Modifier: {shield} ({name})",
@@ -821,6 +821,7 @@
             "Identified"     : "Identified",
             "MaxDex"         : "Max. Dexterity Modifier",
             "Proficient"     : "Proficient",
+            "NotProficient"  : "Not Proficient",
             "Unlimited"      : "Unlimited",
             "Action": {
                 "ActionType"            : "Action Type",
@@ -939,16 +940,24 @@
                 "Details": "Magic Item Details"
             },
             "Shield": {
-                "Action" : "Shield Action",
-                "Aligned": "Aligned",
-                "Bonus"  : "Shield Bonus",
-                "Details": "Shield Details",
-                "Wielded": "Wielded"
+                "Action"     : "Shield Action",
+                "AcMaxDex"   : "Max dex bonus: {maxDex}",
+                "ACP"        : "ACP: {acp}",
+                "Aligned"    : "Aligned",
+                "ArmorCheck" : "Armor check penalty: {acp}",
+                "Bonus"      : "Shield Bonus",
+                "Bonuses"    : "Wielded bonus: {wielded} / Aligned bonus: {aligned}",
+                "Details"    : "Shield Details",
+                "Dex"        : "Dex: {dex}",
+                "Shield"     : "Shield",
+                "ShieldBonus": "Shield: {wielded} / {aligned}",
+                "Wielded"    : "Wielded"
             },
             "ShipWeapon": {
                 "ItemType"    :"Starship Weapon",
                 "Source"      : "Source",
                 "Mounted"     : "Mounted",
+                "NotMounted"  : "Not Mounted",
                 "Activated"   : "Activated",
                 "WeaponArc"   : "Weapon Arc",
                 "WeaponClass" : "Weapon Class",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -98,7 +98,9 @@
         "ACTooltipBase": "基本ＡＣ: {base}",
         "ACTooltipBonus": "{type} ボーナス: {mod} ({source})",
         "ACTooltipMaxDex": "敏捷力修正値: {maxDex} (armor max dex: {armorMax})",
-        "ACTooltipNotProficientMod": "未習熟ペナルティ: {profMod}",
+        "ACTooltipNotProficientMod": "Penalty for armor non-proficiency: {profMod}",
+        "ACTooltipNotProficientShield": "Penalty for shield non-proficiency: {profMod}",
+        "ACTooltipShieldACMod": "Shield Modifier: {shield} ({name})",
         "ActorSheet": {
             "Attributes": {
                 "Skills": {

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -44,6 +44,7 @@ export class ActorSFRPG extends Actor {
         const actorId = this._id;
         const items = actorData.items;
         const armor = items.find(item => item.type === "equipment" && item.data.equipped);
+        const shields = items.filter(item => item.type === "shield" && item.data.equipped);
         const weapons = items.filter(item => item.type === "weapon" && item.data.equipped);
         const races = items.filter(item => item.type === "race");
         const frames = items.filter(item => item.type === "starshipFrame");
@@ -61,6 +62,7 @@ export class ActorSFRPG extends Actor {
             flags,
             items,
             armor,
+            shields,
             weapons,
             races,
             classes,

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -440,11 +440,14 @@ export class ItemSFRPG extends Item {
      * @param {Object} props The items properties
      */
     _shieldChatData(data, labels, props) {
+        let wieldedBonus = data.proficient ? data.bonus.wielded.toString() : "0";
+        let alignedBonus = data.proficient ? data.bonus.aligned.toString() : "0";
+
         props.push(
             "Shield",
             "Max dex bonus : " + data.dex.toString(),
             "Armor check penalty: " + data.acp.toString(),
-            "Wielded bonus: " + data.bonus.wielded.toString() + " / Aligned bonus: " + data.bonus.aligned.toString(),
+            "Wielded bonus: " + wieldedBonus + " / Aligned bonus: " + alignedBonus,
             data.proficient ? "Proficient" : "Not Proficient"
         );
     }

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -429,7 +429,7 @@ export class ItemSFRPG extends Item {
             data.weaponType ? CONFIG.SFRPG.starshipWeaponTypes[data.weaponType] : null,
             data.class ? CONFIG.SFRPG.starshipWeaponClass[data.class] : null,
             data.range ? CONFIG.SFRPG.starshipWeaponRanges[data.range] : null,
-            data.mount.mounted ? "Mounted" : "Not Mounted"
+            data.mount.mounted ? game.i18n.localize("SFRPG.ShipWeapon.Mounted") : game.i18n.localize("SFRPG.ShipWeapon.NotMounted")
         );
     }
 
@@ -444,11 +444,11 @@ export class ItemSFRPG extends Item {
         let alignedBonus = data.proficient ? data.bonus.aligned.toString() : "0";
 
         props.push(
-            "Shield",
-            "Max dex bonus : " + data.dex.toString(),
-            "Armor check penalty: " + data.acp.toString(),
-            "Wielded bonus: " + wieldedBonus + " / Aligned bonus: " + alignedBonus,
-            data.proficient ? "Proficient" : "Not Proficient"
+            game.i18n.localize("SFRPG.Items.Shield.Shield"),
+            game.i18n.format("SFRPG.Items.Shield.AcMaxDex", { maxDex: data.dex.signedString() }),
+            game.i18n.format("SFRPG.Items.Shield.ArmorCheck", { acp: data.acp.signedString() }),
+            game.i18n.format("SFRPG.Items.Shield.Bonuses", { wielded: wieldedBonus.signedString(), aligned: alignedBonus.signedString() }),
+            data.proficient ? game.i18n.localize("SFRPG.Items.Proficient") : game.i18n.localize("SFRPG.Items.NotProficient")
         );
     }
 

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -225,11 +225,11 @@ export class ItemSheetSFRPG extends ItemSheet {
             props.push(CONFIG.SFRPG.starshipWeaponTypes[item.data.weaponType]);
             props.push(CONFIG.SFRPG.starshipWeaponClass[item.data.class]);
         } else if (item.type === "shield") {
-            if (item.data.dex) props.push(`Dex: ${item.data.dex}`);
-            if (item.data.acp) props.push(`ACP: ${item.data.acp}`);
+            if (item.data.dex) props.push(game.i18n.format("SFRPG.Items.Shield.Dex", { dex: item.data.dex.signedString() }));
+            if (item.data.acp) props.push(game.i18n.format("SFRPG.Items.Shield.ACP", { acp: item.data.acp.signedString() }));
             let wieldedBonus = item.data.proficient ? item.data.bonus.wielded : 0;
             let alignedBonus = item.data.proficient ? item.data.bonus.aligned : 0;
-            props.push(`Shield: ${wieldedBonus}/${alignedBonus}`);
+            props.push(game.i18n.format("SFRPG.Items.Shield.ShieldBonus", { wielded: wieldedBonus.signedString(), aligned: alignedBonus.signedString() }));
         }
 
         // Action type

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -227,7 +227,9 @@ export class ItemSheetSFRPG extends ItemSheet {
         } else if (item.type === "shield") {
             if (item.data.dex) props.push(`Dex: ${item.data.dex}`);
             if (item.data.acp) props.push(`ACP: ${item.data.acp}`);
-            props.push(`Shield: ${item.data.bonus.wielded}/${item.data.bonus.aligned}`);
+            let wieldedBonus = item.data.proficient ? item.data.bonus.wielded : 0;
+            let alignedBonus = item.data.proficient ? item.data.bonus.aligned : 0;
+            props.push(`Shield: ${wieldedBonus}/${alignedBonus}`);
         }
 
         // Action type

--- a/src/module/rules/actions/actor/calculate-base-armor-class.js
+++ b/src/module/rules/actions/actor/calculate-base-armor-class.js
@@ -1,3 +1,5 @@
+import { SFRPG } from "../../../config.js";
+
 export default function (engine) {
     engine.closures.add("calculateBaseArmorClass", (fact, context) => {
         const data = fact.data;
@@ -20,8 +22,8 @@ export default function (engine) {
             const maxDex = Math.min(data.abilities.dex.mod, maxArmorDex, maxShieldDex);
             const maxDexTooltip = game.i18n.format("SFRPG.ACTooltipMaxDex", { 
                 maxDex: maxDex.signedString(), 
-                armorMax: armor?.data.armor.dex?.signedString() ?? "unlimited",
-                shieldMax: shield?.data.dex?.signedString() ?? "unlimited"
+                armorMax: armor?.data.armor.dex?.signedString() ?? game.i18n.localize("SFRPG.Items.Unlimited"),
+                shieldMax: shield?.data.dex?.signedString() ?? game.i18n.localize("SFRPG.Items.Unlimited")
             });
 
             // AC bonuses
@@ -42,8 +44,7 @@ export default function (engine) {
 
                 if (shield.data.proficient) {
                     shieldBonus = shieldProfBonus;
-                }
-                else {
+                } else {
                     const shieldNotProfTooltip = game.i18n.format("SFRPG.ACTooltipNotProficientShield", { profMod: -shieldProfBonus });
                     eac.tooltip.push(shieldNotProfTooltip);
                     kac.tooltip.push(shieldNotProfTooltip);
@@ -58,11 +59,11 @@ export default function (engine) {
             kac.value = 10 + kacMod;
             
             if (armor) eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorEac.signedString(), name: armor.name }));
-            if (shield) eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shieldBonus.signedString(), name: shield.name }));
+            if (shield) eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shield.data.bonus.wielded.signedString(), name: shield.name }));
             eac.tooltip.push(maxDexTooltip);
 
             if (armor) kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorKac.signedString(), name: armor.name }));
-            if (shield) kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shieldBonus.signedString(), name: shield.name }));
+            if (shield) kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shield.data.bonus.wielded.signedString(), name: shield.name }));
             kac.tooltip.push(maxDexTooltip);
         } else {
             eac.value = 10 + data.abilities.dex.mod;

--- a/src/module/rules/actions/actor/calculate-base-armor-class.js
+++ b/src/module/rules/actions/actor/calculate-base-armor-class.js
@@ -2,6 +2,7 @@ export default function (engine) {
     engine.closures.add("calculateBaseArmorClass", (fact, context) => {
         const data = fact.data;
         const armor = fact.armor;
+        const shields = fact.shields;
         const eac = data.attributes.eac;
         const kac = data.attributes.kac;
         const baseTooltip = game.i18n.format("SFRPG.ACTooltipBase", { base: "10" });
@@ -10,30 +11,58 @@ export default function (engine) {
         eac.tooltip.push(baseTooltip);
         kac.tooltip.push(baseTooltip);
 
-        if (armor) {
-            const maxDex = Math.min(data.abilities.dex.mod, armor.data.armor.dex ?? Number.MAX_SAFE_INTEGER);
+        if (armor || shields) {
+            // Max dex
+            const shield = shields?.sort((a, b) => a.data.dex <= b.data.dex ? -1 : 1)[0];
+            let maxShieldDex = shield?.data.dex ?? Number.MAX_SAFE_INTEGER;
+            let maxArmorDex = armor?.data.armor.dex ?? Number.MAX_SAFE_INTEGER;
+
+            const maxDex = Math.min(data.abilities.dex.mod, maxArmorDex, maxShieldDex);
             const maxDexTooltip = game.i18n.format("SFRPG.ACTooltipMaxDex", { 
                 maxDex: maxDex.signedString(), 
-                armorMax: armor.data.armor.dex?.signedString() ?? "unlimited"
+                armorMax: armor?.data.armor.dex?.signedString() ?? "unlimited",
+                shieldMax: shield?.data.dex?.signedString() ?? "unlimited"
             });
-            
-            let eacMod = armor.data.armor.eac + maxDex;
-            let kacMod = armor.data.armor.kac + maxDex;
-            
-            if (!armor.data.proficient) {
-                eacMod -= 4;
-                kacMod -= 4;
+
+            // AC bonuses
+            let armorEac = armor?.data.armor.eac ?? 0;
+            let armorKac = armor?.data.armor.kac ?? 0;
+
+            if (armor && !armor.data.proficient) {
+                armorEac -= 4;
+                armorKac -= 4;
 
                 eac.tooltip.push(notProfTooltip);
                 kac.tooltip.push(notProfTooltip);
             }
 
+            let shieldBonus = 0;
+            if (shield) {
+                let shieldProfBonus = shield.data.bonus.wielded;
+
+                if (shield.data.proficient) {
+                    shieldBonus = shieldProfBonus;
+                }
+                else {
+                    const shieldNotProfTooltip = game.i18n.format("SFRPG.ACTooltipNotProficientShield", { profMod: -shieldProfBonus });
+                    eac.tooltip.push(shieldNotProfTooltip);
+                    kac.tooltip.push(shieldNotProfTooltip);
+                }
+            }
+
+            let eacMod = armorEac + shieldBonus + maxDex;
+            let kacMod = armorKac + shieldBonus + maxDex;
+
+            // AC
             eac.value = 10 + eacMod;
             kac.value = 10 + kacMod;
             
-            eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armor.data.armor.eac.signedString(), name: armor.name }));
+            if (armor) eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorEac.signedString(), name: armor.name }));
+            if (shield) eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shieldBonus.signedString(), name: shield.name }));
             eac.tooltip.push(maxDexTooltip);
-            kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armor.data.armor.kac.signedString(), name: armor.name }));
+
+            if (armor) kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorKac.signedString(), name: armor.name }));
+            if (shield) kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shieldBonus.signedString(), name: shield.name }));
             kac.tooltip.push(maxDexTooltip);
         } else {
             eac.value = 10 + data.abilities.dex.mod;

--- a/src/template.json
+++ b/src/template.json
@@ -474,10 +474,6 @@
                 "armorProf": {
                     "value": [],
                     "custom": ""
-                },
-                "shieldProf": {
-                    "value": [],
-                    "custom": ""
                 }
             },
             "resources": {
@@ -1307,8 +1303,7 @@
             },
             "proficiencies": {
                 "weapon": {},
-                "armor": {},
-                "shield": {}
+                "armor": {}
             },
             "bab": "moderate",
             "fort": "slow",
@@ -1604,7 +1599,7 @@
             "damage": {
                 "parts": []
             },
-            "proficient": true,
+            "proficient": false,
             "container": {
                 "contents": [],
                 "storage": [


### PR DESCRIPTION
Includes latest errata...
- updated item stats 
- updated physical item traits for HP, AC, and Hardness
- equipped shields without proficiency do not provide a bonus (reflected in descriptions)
- added wielded bonus to AC values for PCs (0 if not proficient)
- added tooltip values and penalties for PCs (if not proficient)

![image](https://user-images.githubusercontent.com/2079751/103323663-47564600-4a44-11eb-807e-95422c7c71ad.png)
