### PR TITLE
AC calculations now correctly handle multiple shields equipped at the same time

### DIFF
--- a/src/module/rules/actions/actor/calculate-base-armor-class.js
+++ b/src/module/rules/actions/actor/calculate-base-armor-class.js
@@ -15,15 +15,15 @@ export default function (engine) {
 
         if (armor || shields) {
             // Max dex
-            const shield = shields?.sort((a, b) => a.data.dex <= b.data.dex ? -1 : 1)[0];
-            let maxShieldDex = shield?.data.dex ?? Number.MAX_SAFE_INTEGER;
+            const shieldMinDex = shields?.sort((a, b) => a.data.dex <= b.data.dex ? -1 : 1)[0];
+            let maxShieldDex = shieldMinDex?.data.dex ?? Number.MAX_SAFE_INTEGER;
             let maxArmorDex = armor?.data.armor.dex ?? Number.MAX_SAFE_INTEGER;
 
             const maxDex = Math.min(data.abilities.dex.mod, maxArmorDex, maxShieldDex);
             const maxDexTooltip = game.i18n.format("SFRPG.ACTooltipMaxDex", { 
                 maxDex: maxDex.signedString(), 
                 armorMax: armor?.data.armor.dex?.signedString() ?? game.i18n.localize("SFRPG.Items.Unlimited"),
-                shieldMax: shield?.data.dex?.signedString() ?? game.i18n.localize("SFRPG.Items.Unlimited")
+                shieldMax: shieldMinDex?.data.dex?.signedString() ?? game.i18n.localize("SFRPG.Items.Unlimited")
             });
 
             // AC bonuses
@@ -38,14 +38,17 @@ export default function (engine) {
                 kac.tooltip.push(notProfTooltip);
             }
 
-            let shieldBonus = 0;
-            if (shield) {
-                let shieldProfBonus = shield.data.bonus.wielded;
+            let shieldBonus       = 0;
+            let totalShieldBonus  = 0;
+            
+            if (shields) {
+                shields.forEach(shield => {
+                    totalShieldBonus += shield.data.bonus.wielded;
+                    if (shield.data.proficient) shieldBonus += shield.data.bonus.wielded;
+                });
 
-                if (shield.data.proficient) {
-                    shieldBonus = shieldProfBonus;
-                } else {
-                    const shieldNotProfTooltip = game.i18n.format("SFRPG.ACTooltipNotProficientShield", { profMod: -shieldProfBonus });
+                if (shieldBonus !== totalShieldBonus) {
+                    const shieldNotProfTooltip = game.i18n.format("SFRPG.ACTooltipNotProficientShield", { profMod: shieldBonus - totalShieldBonus });
                     eac.tooltip.push(shieldNotProfTooltip);
                     kac.tooltip.push(shieldNotProfTooltip);
                 }
@@ -59,11 +62,11 @@ export default function (engine) {
             kac.value = 10 + kacMod;
             
             if (armor) eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorEac.signedString(), name: armor.name }));
-            if (shield) eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shield.data.bonus.wielded.signedString(), name: shield.name }));
+            if (shields) shields.forEach(shield => eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shield.data.bonus.wielded.signedString(), name: shield.name })));
             eac.tooltip.push(maxDexTooltip);
 
             if (armor) kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorKac.signedString(), name: armor.name }));
-            if (shield) kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shield.data.bonus.wielded.signedString(), name: shield.name }));
+            if (shields) shields.forEach(shield => kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: shield.data.bonus.wielded.signedString(), name: shield.name })));
             kac.tooltip.push(maxDexTooltip);
         } else {
             eac.value = 10 + data.abilities.dex.mod;

--- a/src/module/rules/actions/actor/calculate-skill-armor-check-penalty.js
+++ b/src/module/rules/actions/actor/calculate-skill-armor-check-penalty.js
@@ -3,6 +3,7 @@ import { SFRPGEffectType, SFRPGModifierType, SFRPGModifierTypes } from "../../..
 export default function (engine) {
     engine.closures.add("calculateSkillArmorCheckPenalty", (fact, context) => {
         const armor = fact.armor;
+        const shields = fact.shields;
         const skills = fact.data.skills;
         const modifiers = fact.modifiers;
 
@@ -83,6 +84,23 @@ export default function (engine) {
                         source: armor.name
                     }));
                 }
+            }
+
+            if (shields) {
+                shields.forEach(shield => {
+                    if (shield.data?.acp) {
+                        let acp = parseInt(shield.data.acp);
+                        if (!Number.isNaN(acp)) {
+                            skill.mod += acp;
+
+                            skill.tooltip.push(game.i18n.format("SFRPG.ACPTooltip", {
+                                type: "Shield",
+                                mod: acp.signedString(),
+                                source: shield.name
+                            }));
+                        }
+                    }
+                });
             }
 
             if (skillModifier.tooltip.length !== 0) {


### PR DESCRIPTION
In the tooltip below you see two shields with different names. "1st shield" has proficiency checked but "2nd shield" does not. They are otherwise identical.
![image](https://user-images.githubusercontent.com/2079751/103441381-cec2d580-4c4d-11eb-9b3f-5545782579a2.png)
![image](https://user-images.githubusercontent.com/2079751/103441338-7ab7f100-4c4d-11eb-9ba1-d9665379c4e0.png)
