### PR TITLE
Future proofing/add default save object

### DIFF
--- a/src/template.json
+++ b/src/template.json
@@ -1609,7 +1609,11 @@
             "damage": {
                 "parts": []
             },
-            "save": {}
+            "save": {
+                "type": "",
+                "dc": null,
+                "descriptor": ""
+            }
         },
         "mod": {
             "templates": ["itemDescription", "modifiers"],


### PR DESCRIPTION
Small tweak which adds default `save` object to `Vehicle Attack` type items. This wasn't needed for 0.7.9 but seems like it's probably a good pattern to maintain as other objects with saves provide a similar default object, and prevents a migration step which would be required on updating to 0.8.0 (based on current state of alpha).