### PR TITLE
Foundry/update to 080

### DIFF
--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -154,7 +154,7 @@ export class ItemSheetSFRPG extends ItemSheet {
 
         // Spell-specific data
         if (data.item.type === "spell") {
-            let save = data.item.data.save;
+            let save = data.item.data.data.save;
             if (this.item.isOwned && (save.type && !save.dc)) {
                 let actor = this.item.actor;
                 let abl = actor.data.data.attributes.keyability || "int";
@@ -165,7 +165,7 @@ export class ItemSheetSFRPG extends ItemSheet {
         // Vehicle Attacks
         if (data.isVehicleAttack) {
             data.placeholders.savingThrow = {};
-            data.placeholders.savingThrow.value = data.item.data.save.dc;
+            data.placeholders.savingThrow.value = data.item.data.data.save.dc;
         }
 
         data.modifiers = this.item.data.data.modifiers;

--- a/src/template.json
+++ b/src/template.json
@@ -1609,7 +1609,11 @@
             "damage": {
                 "parts": []
             },
-            "save": {}
+            "save": {
+                "type": "",
+                "dc": null,
+                "descriptor": ""
+            }
         },
         "mod": {
             "templates": ["itemDescription", "modifiers"],

--- a/src/templates/items/vehicleAttack.html
+++ b/src/templates/items/vehicleAttack.html
@@ -58,7 +58,7 @@
                 <a class="damage-control add-damage"><i class="fas fa-plus"></i></a>
             </h4>
             <ol class="damage-parts form-group">
-                {{#each data.damage.parts as |part i| }}
+                {{#each data.data.damage.parts as |part i| }}
                 <li class="damage-part flexrow" data-damage-part="{{i}}">
                     <input type="text" name="data.damage.parts.{{i}}.0" value="{{lookup this "0"}}"/>
                     <select name="data.damage.parts.{{i}}.1">
@@ -81,9 +81,9 @@
             <div class="form-group input-select">
                 <label>{{ localize "SFRPG.Items.Action.SavingThrow" }}</label>
                 <div class="form-fields">
-                    <input type="text" name="data.save.dc" value="{{data.save.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
+                    <input type="text" name="data.save.dc" value="{{data.data.save.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
                     <select name="data.save.type">
-                        {{#select data.save.type}}
+                        {{#select data.data.save.type}}
                         <option value=""></option>
                         {{#each config.saves as |save s|}}
                         <option value="{{s}}">{{save}}</option>
@@ -91,7 +91,7 @@
                         {{/select}}
                     </select>
                     <select name="data.save.descriptor">
-                        {{#select data.save.descriptor}}
+                        {{#select data.data.save.descriptor}}
                         {{#each config.saveDescriptors as |descriptor k|}}
                         <option value="{{k}}">{{descriptor}}</option>
                         {{/each}}


### PR DESCRIPTION
Changed two references in `item/sheet.js` which now require to access a `data` object 1 level deeper. Also some similar changes in VehicleAttack.html. This provides a minor fixes to the weapon attack sheet. 

Also tweaks the template of Vehicle Attacks to add a default save (this has been back ported to develop branch for a Foundry 0.7.9 compatible update in a separate PR here: https://github.com/wildj79/foundryvtt-starfinder/pull/288) . 