### PR TITLE
Added the `Cold & Slashing` damage type.

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -601,6 +601,7 @@
         "DamageTypesBludgeoningAndSonic": "Wucht & Schall",
         "DamageTypesCold": "Kälte",
         "DamageTypesColdAndPiercing": "Kälte & Stich",
+        "DamageTypesColdAndSlashing": "Kälte & Hieb",
         "DamageTypesColdOrFire": "Kälte | Feuer",
         "DamageTypesElectricity": "Elektrizität",
         "DamageTypesElectricityAndFire": "Elektrizität & Feuer",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -601,6 +601,7 @@
         "DamageTypesBludgeoningAndSonic": "Bludgeoning & Sonic",
         "DamageTypesCold": "Cold",
         "DamageTypesColdAndPiercing": "Cold & Piercing",
+        "DamageTypesColdAndSlashing": "Cold & Slashing",
         "DamageTypesColdOrFire": "Cold | Fire",
         "DamageTypesElectricity": "Electricity",
         "DamageTypesElectricityAndFire": "Electricity & Fire",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -601,6 +601,7 @@
         "DamageTypesBludgeoningAndSonic": "Contondant & Sonique",
         "DamageTypesCold": "Froid",
         "DamageTypesColdAndPiercing": "Froid & Perforant",
+        "DamageTypesColdAndSlashing": "Froid & Tranchant",
         "DamageTypesColdOrFire": "Froid | Feu",
         "DamageTypesElectricity": "Electricité",
         "DamageTypesElectricityAndFire": "Electricité & Feu",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -601,6 +601,7 @@
         "DamageTypesBludgeoningAndSonic": "[殴打] & [音波]",
         "DamageTypesCold": "[冷気]",
         "DamageTypesColdAndPiercing": "[冷気] & [刺突]",
+        "DamageTypesColdAndSlashing": "[冷気] & [斬撃]",
         "DamageTypesColdOrFire": "[冷気] | [火]",
         "DamageTypesElectricity": "[電気]",
         "DamageTypesElectricityAndFire": "[電気] & [火]",

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -159,6 +159,7 @@ SFRPG.weaponDamageTypes = {
     "acid|slashing": "SFRPG.DamageTypesAcidOrSlashing",    
     "cold": "SFRPG.DamageTypesCold",
     "cold+piercing": "SFRPG.DamageTypesColdAndPiercing",
+    "cold+slashing": "SFRPG.DamageTypesColdAndSlashing",
     "cold|fire": "SFRPG.DamageTypesColdOrFire",
     "electricity": "SFRPG.DamageTypesElectricity",
     "electricity+fire": "SFRPG.DamageTypesElectricityAndFire",


### PR DESCRIPTION
We are missing the Cold and Slashing damage type. 

Example: The Glaiad in AP 35 pg. 58:
`Melee iceblade +9 (1d8+6 C & S)`
