### PR TITLE
Update Gulp workflow for Docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "package": "gulp package",
     "build": "gulp build && gulp link",
+    "buildDock": "gulp build && gulp copyUser",
     "build:watch": "gulp watch",
     "cook": "gulp cook",
     "clean": "gulp clean && gulp link --clean",
+    "cleanDock": "gulp clean && gulp copyUser --clean",
     "libs": "gulp libs",
     "update": "npm install --save-dev gitlab:foundry-projects/foundry-pc/foundry-pc-types",
     "unpack": "gulp unpack"


### PR DESCRIPTION
Updated gulp.js and package.json with copy action vs. symlink. Docker hates symlinks. Also added a buildDock and cleanDock command for easier usage and avoid impacting the current workflow.