### PR TITLE
Fixed unslottable spells

### DIFF
--- a/src/module/actor/actor-inventory.js
+++ b/src/module/actor/actor-inventory.js
@@ -530,7 +530,7 @@ export function getFirstAcceptableStorageIndex(container, itemToAdd) {
             continue;
         }
 
-        if (storageOption.weightProperty && !itemToAdd.data.data[storageOption.weightProperty]) {
+        if (storageOption.weightProperty && !itemToAdd.data.data[storageOption.weightProperty] && !itemToAdd.type == 'spell') {
             //console.log(`Skipping storage ${index} because it does not match the weight settings.`);
             continue;
         }


### PR DESCRIPTION
# What has been fixed
Fixed a bug that prevented to slot spells inside containers. Now the system is capable of doing so, but only when a spell is dragged and dropped from a compendium window.

# Explanation of the issue
The system, before putting the item inside a container, performs multiple checks and one of these checks is the weigth. Since spells do not have the weight property, the code "!itemToAdd.data.data[storageOption.weightProperty]" will always return true (negated false) and, as such, the system will always call "continue;". For this reason, the function will always return "null".

# Future Work
My proposed solution is a "bandaid" fix and should not be used for extended periods of time. A proper solution involves checking the existance of every property and making sure that every item has every property.