### PR TITLE
Added full data for status effects

### DIFF
--- a/src/module/config.js
+++ b/src/module/config.js
@@ -1047,43 +1047,183 @@ SFRPG.CR_EXP_LEVELS = [
     153600, 204800, 307200, 409600, 614400, 819200, 1228800, 1638400
 ];
 
-SFRPG.statusEffectIcons = [
-    "systems/sfrpg/icons/conditions/asleep.png",
-    "systems/sfrpg/icons/conditions/bleeding.png",
-    "systems/sfrpg/icons/conditions/blinded.png",
-    "systems/sfrpg/icons/conditions/broken.png",
-    "systems/sfrpg/icons/conditions/burning.png",
-    "systems/sfrpg/icons/conditions/confused.png",
-    "systems/sfrpg/icons/conditions/cowering.png",
-    "systems/sfrpg/icons/conditions/dazed.png",
-    "systems/sfrpg/icons/conditions/dazzled.png",
-    "systems/sfrpg/icons/conditions/dead.png",
-    "systems/sfrpg/icons/conditions/deafened.png",
-    "systems/sfrpg/icons/conditions/dying.png",
-    "systems/sfrpg/icons/conditions/encumbered.png",
-    "systems/sfrpg/icons/conditions/entangled.png",
-    "systems/sfrpg/icons/conditions/exhausted.png",
-    "systems/sfrpg/icons/conditions/fascinated.png",
-    "systems/sfrpg/icons/conditions/fatigued.png",
-    "systems/sfrpg/icons/conditions/flatfooted.png",
-    "systems/sfrpg/icons/conditions/frightened.png",
-    "systems/sfrpg/icons/conditions/grappled.png",
-    "systems/sfrpg/icons/conditions/helpless.png",
-    "systems/sfrpg/icons/conditions/nauseated.png",
-    "systems/sfrpg/icons/conditions/offkilter.png",
-    "systems/sfrpg/icons/conditions/offtarget.png",
-    "systems/sfrpg/icons/conditions/overburdened.png",
-    "systems/sfrpg/icons/conditions/panicked.png",
-    "systems/sfrpg/icons/conditions/paralyzed.png",
-    "systems/sfrpg/icons/conditions/pinned.png",
-    "systems/sfrpg/icons/conditions/prone.png",
-    "systems/sfrpg/icons/conditions/shaken.png",
-    "systems/sfrpg/icons/conditions/sickened.png",
-    "systems/sfrpg/icons/conditions/staggered.png",
-    "systems/sfrpg/icons/conditions/stable.png",
-    "systems/sfrpg/icons/conditions/stunned.png",
-    "systems/sfrpg/icons/conditions/unconscious.png"
-];
+SFRPG.statusEffects = [
+    {
+        id: "asleep",
+        label: "SFRPG.ConditionsAsleep",
+        icon: "systems/sfrpg/icons/conditions/asleep.png"
+    },
+    {
+        id: "bleeding",
+        label: "SFRPG.ConditionsBleeding",
+        icon: "systems/sfrpg/icons/conditions/bleeding.png"
+    },
+    {
+        id: "blinded",
+        label: "SFRPG.ConditionsBlinded",
+        icon: "systems/sfrpg/icons/conditions/blinded.png"
+    },
+    {
+        id: "broken",
+        label: "SFRPG.ConditionsBroken",
+        icon: "systems/sfrpg/icons/conditions/broken.png"
+    },
+    {
+        id: "burning",
+        label: "SFRPG.ConditionsBurning",
+        icon: "systems/sfrpg/icons/conditions/burning.png"
+    },
+    {
+        id: "confused",
+        label: "SFRPG.ConditionsConfused",
+        icon: "systems/sfrpg/icons/conditions/confused.png"
+    },
+    {
+        id: "cowering",
+        label: "SFRPG.ConditionsCowering",
+        icon: "systems/sfrpg/icons/conditions/cowering.png"
+    },
+    {
+        id: "dazed",
+        label: "SFRPG.ConditionsDazed",
+        icon: "systems/sfrpg/icons/conditions/dazed.png"
+    },
+    {
+        id: "dazzled",
+        label: "SFRPG.ConditionsDazzled",
+        icon: "systems/sfrpg/icons/conditions/dazzled.png"
+    },
+    {
+        id: "dead",
+        label: "SFRPG.ConditionsDead",
+        icon: "systems/sfrpg/icons/conditions/dead.png"
+    },
+    {
+        id: "deafened",
+        label: "SFRPG.ConditionsDeafened",
+        icon: "systems/sfrpg/icons/conditions/deafened.png"
+    },
+    {
+        id: "dying",
+        label: "SFRPG.ConditionsDying",
+        icon: "systems/sfrpg/icons/conditions/dying.png"
+    },
+    {
+        id: "encumbered",
+        label: "SFRPG.ConditionsEncumbered",
+        icon: "systems/sfrpg/icons/conditions/encumbered.png"
+    },
+    {
+        id: "entangled",
+        label: "SFRPG.ConditionsEntangled",
+        icon: "systems/sfrpg/icons/conditions/entangled.png"
+    },
+    {
+        id: "exhausted",
+        label: "SFRPG.ConditionsExhausted",
+        icon: "systems/sfrpg/icons/conditions/exhausted.png"
+    },
+    {
+        id: "fascinated",
+        label: "SFRPG.ConditionsFascinated",
+        icon: "systems/sfrpg/icons/conditions/fascinated.png"
+    },
+    {
+        id: "fatigued",
+        label: "SFRPG.ConditionsFatigued",
+        icon: "systems/sfrpg/icons/conditions/fatigued.png"
+    },
+    {
+        id: "flat-footed",
+        label: "SFRPG.ConditionsFlatFooted",
+        icon: "systems/sfrpg/icons/conditions/flatfooted.png"
+    },
+    {
+        id: "frightened",
+        label: "SFRPG.ConditionsFrightened",
+        icon: "systems/sfrpg/icons/conditions/frightened.png"
+    },
+    {
+        id: "grappled",
+        label: "SFRPG.ConditionsGrappled",
+        icon: "systems/sfrpg/icons/conditions/grappled.png"
+    },
+    {
+        id: "helpless",
+        label: "SFRPG.ConditionsHelpless",
+        icon: "systems/sfrpg/icons/conditions/helpless.png"
+    },
+    {
+        id: "nauseated",
+        label: "SFRPG.ConditionsNauseated",
+        icon: "systems/sfrpg/icons/conditions/nauseated.png"
+    },
+    {
+        id: "off-kilter",
+        label: "SFRPG.ConditionsOffKilter",
+        icon: "systems/sfrpg/icons/conditions/offkilter.png"
+    },
+    {
+        id: "off-target",
+        label: "SFRPG.ConditionsOffTarget",
+        icon: "systems/sfrpg/icons/conditions/offtarget.png"
+    },
+    {
+        id: "overburdened",
+        label: "SFRPG.ConditionsOverburdened",
+        icon: "systems/sfrpg/icons/conditions/overburdened.png"
+    },
+    {
+        id: "panicked",
+        label: "SFRPG.ConditionsPanicked",
+        icon: "systems/sfrpg/icons/conditions/panicked.png"
+    },
+    {
+        id: "paralyzed",
+        label: "SFRPG.ConditionsParalyzed",
+        icon: "systems/sfrpg/icons/conditions/paralyzed.png"
+    },
+    {
+        id: "pinned",
+        label: "SFRPG.ConditionsPinned",
+        icon: "systems/sfrpg/icons/conditions/pinned.png"
+    },
+    {
+        id: "prone",
+        label: "SFRPG.ConditionsProne",
+        icon: "systems/sfrpg/icons/conditions/prone.png"
+    },
+    {
+        id: "shaken",
+        label: "SFRPG.ConditionsShaken",
+        icon: "systems/sfrpg/icons/conditions/shaken.png"
+    },
+    {
+        id: "sickened",
+        label: "SFRPG.ConditionsSickened",
+        icon: "systems/sfrpg/icons/conditions/sickened.png"
+    },
+    {
+        id: "stable",
+        label: "SFRPG.ConditionsStable",
+        icon: "systems/sfrpg/icons/conditions/stable.png"
+    },
+    {
+        id: "staggered",
+        label: "SFRPG.ConditionsStaggered",
+        icon: "systems/sfrpg/icons/conditions/staggered.png"
+    },
+    {
+        id: "stunned",
+        label: "SFRPG.ConditionsStunned",
+        icon: "systems/sfrpg/icons/conditions/stunned.png"
+    },
+    {
+        id: "unconscious",
+        label: "SFRPG.ConditionsUnconscious",
+        icon: "systems/sfrpg/icons/conditions/unconscious.png"
+    }
+]
 
 SFRPG.statusEffectIconMapping = {
     "asleep": "systems/sfrpg/icons/conditions/asleep.png",

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -126,7 +126,7 @@ Hooks.once('init', async function () {
     };
 
     CONFIG.SFRPG = SFRPG;
-    CONFIG.statusEffects = CONFIG.SFRPG.statusEffectIcons;
+    CONFIG.statusEffects = CONFIG.SFRPG.statusEffects;
 
     console.log("Starfinder | [INIT] Overriding document classes");
     CONFIG.Actor.documentClass = ActorSFRPG;


### PR DESCRIPTION
Changes the data format to provide metadata required for modules and any further development of statuses. The effects of this can be seen in the final HTML
![image](https://user-images.githubusercontent.com/2079751/141704607-be5817d7-3794-492f-805c-8dcc84b29629.png)
