### PR TITLE
Small tweak for the activation button on active feats

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -61,6 +61,7 @@
         "AbilityActivationTypesMinute": "Minute",
         "AbilityActivationTypesMove": "Bewegungsaktion",
         "AbilityActivationTypesNone": "Keine",
+        "AbilityActivationTypesNoneButton": "Activate",
         "AbilityActivationTypesOther": "Andere Aktionen",
         "AbilityActivationTypesReaction": "Reaktion",
         "AbilityActivationTypesSpecial": "Spezial",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -61,6 +61,7 @@
         "AbilityActivationTypesMinute": "Minute",
         "AbilityActivationTypesMove": "M. Action",
         "AbilityActivationTypesNone": "None",
+        "AbilityActivationTypesNoneButton": "Activate",
         "AbilityActivationTypesOther": "Other Actions",
         "AbilityActivationTypesReaction": "Reaction",
         "AbilityActivationTypesSpecial": "Special",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -61,6 +61,7 @@
         "AbilityActivationTypesMinute": "Minute",
         "AbilityActivationTypesMove": "Action de M.",
         "AbilityActivationTypesNone": "Aucune",
+        "AbilityActivationTypesNoneButton": "Activate",
         "AbilityActivationTypesOther": "Autres actions",
         "AbilityActivationTypesReaction": "Réaction",
         "AbilityActivationTypesSpecial": "Spécial",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -61,6 +61,7 @@
         "AbilityActivationTypesMinute": "Minuto",
         "AbilityActivationTypesMove": "Azione di Movimento",
         "AbilityActivationTypesNone": "Nulla",
+        "AbilityActivationTypesNoneButton": "Activate",
         "AbilityActivationTypesOther": "Altra Azione",
         "AbilityActivationTypesReaction": "Reazione",
         "AbilityActivationTypesSpecial": "Speciale",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -61,6 +61,7 @@
         "AbilityActivationTypesMinute": "分",
         "AbilityActivationTypesMove": "移動ｱｸｼｮﾝ",
         "AbilityActivationTypesNone": "なし",
+        "AbilityActivationTypesNoneButton": "Activate",
         "AbilityActivationTypesOther": "他ｱｸｼｮﾝ",
         "AbilityActivationTypesReaction": "反射ｱｸｼｮﾝ",
         "AbilityActivationTypesSpecial": "特殊",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -61,6 +61,7 @@
         "AbilityActivationTypesMinute": "Minuto",
         "AbilityActivationTypesMove": "Ação Mv.",
         "AbilityActivationTypesNone": "Nenhuma",
+        "AbilityActivationTypesNoneButton": "Activate",
         "AbilityActivationTypesOther": "Outras Ações",
         "AbilityActivationTypesReaction": "Reação",
         "AbilityActivationTypesSpecial": "Especial",

--- a/src/less/actors.less
+++ b/src/less/actors.less
@@ -758,6 +758,10 @@
         background: @sfrpgGreen;
         color: #fff;
         cursor: pointer;
+
+        &:hover, &:focus{
+          box-shadow: 0 0 5px @sfrpgGreen;
+        }
       }
     }
 

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -96,7 +96,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             let act = data.activation || {};
             if (act) labels.activation = [
                 act.cost,
-                act.type === "none" ? null : C.abilityActivationTypes[act.type]
+                act.type === "none" ? game.i18n.localize("SFRPG.AbilityActivationTypesNoneButton") : C.abilityActivationTypes[act.type]
             ].filterJoin(" ");
 
             let tgt = data.target || {};

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -94,10 +94,17 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
             // Ability Activation Label
             let act = data.activation || {};
-            if (act) labels.activation = [
-                act.cost,
-                act.type === "none" ? game.i18n.localize("SFRPG.AbilityActivationTypesNoneButton") : C.abilityActivationTypes[act.type]
-            ].filterJoin(" ");
+            if (act) {
+                if (act.type === "none"){
+                    labels.activation = game.i18n.localize("SFRPG.AbilityActivationTypesNoneButton");
+                }                 
+                else {
+                    labels.activation = [
+                        act.cost,
+                        C.abilityActivationTypes[act.type]
+                    ].filterJoin(" ");
+                }                
+            }
 
             let tgt = data.target || {};
             if (tgt.value && tgt.value === "") tgt.value = null;


### PR DESCRIPTION
When you have a feat with an activation cost of none the label on the button is set to null leaving a thin and difficult-to-click line instead of a properly sized button. This PR sets the label to "Activate" to indicate that the feat can be activated while not indicating a cost as would normally be the case