### PR TITLE
Add spellcasting ability selector to classes

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -521,6 +521,7 @@
         "ClassSkills": "Klassenfertigkeiten",
         "ClassWeaponProf": "Umgang mit Waffen",
         "ClassWillSaveProgression": "Progression der Willerettungswürfe",
+        "ClassSpellcastingAbility": "Spellcasting Ability",
         "Classes": {
             "IsCasterClass": "Handelt es sich bei der Klasse um einen Zauberwirker?"
         },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -521,7 +521,7 @@
         "ClassSkills": "Class Skills",
         "ClassWeaponProf": "Weapon Proficiencies",
         "ClassWillSaveProgression": "Will Save Progression",
-		"ClassSpellcastingAbility": "Spellcasting Ability",
+        "ClassSpellcastingAbility": "Spellcasting Ability",
         "Classes": {
             "IsCasterClass": "Is this a spell casting class?"
         },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -521,6 +521,7 @@
         "ClassSkills": "Class Skills",
         "ClassWeaponProf": "Weapon Proficiencies",
         "ClassWillSaveProgression": "Will Save Progression",
+		"ClassSpellcastingAbility": "Spellcasting Ability",
         "Classes": {
             "IsCasterClass": "Is this a spell casting class?"
         },

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -521,6 +521,7 @@
         "ClassSkills": "Compétences de classe",
         "ClassWeaponProf": "Maîtrise des armes",
         "ClassWillSaveProgression": "Progression sauvegarde de volonté",
+        "ClassSpellcastingAbility": "Spellcasting Ability",
         "Classes": {
             "IsCasterClass": "S'agit-il d'une classe de lanceur de sorts ?"
         },

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -521,6 +521,7 @@
         "ClassSkills": "Abilità di Classe",
         "ClassWeaponProf": "Competenze nelle Armi",
         "ClassWillSaveProgression": "Progressione Tiro Salvezza Volontà",
+        "ClassSpellcastingAbility": "Spellcasting Ability",
         "Classes": {
             "IsCasterClass": "Questa classe sa lanciare degli Incantesimi?"
         },

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -521,6 +521,7 @@
         "ClassSkills": "クラス技能",
         "ClassWeaponProf": "武器習熟",
         "ClassWillSaveProgression": "意志セーヴの成長度",
+        "ClassSpellcastingAbility": "Spellcasting Ability",
         "Classes": {
             "IsCasterClass": "Is this a spell casting class?"
         },

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -521,6 +521,7 @@
         "ClassSkills": "Perícias de Classe",
         "ClassWeaponProf": "Proficiencia em Armas",
         "ClassWillSaveProgression": "Progressão Save Vontade",
+        "ClassSpellcastingAbility": "Spellcasting Ability",
         "Classes": {
             "IsCasterClass": "Essa classe usa magia?"
         },

--- a/src/module/rules/actions/actor/calculate-classes.js
+++ b/src/module/rules/actions/actor/calculate-classes.js
@@ -11,13 +11,15 @@ export default function (engine) {
 
             const className = cls.name.slugify({replacement: "_", strict: true});
             const keyAbilityScore = classData.kas || "str";
+			const spellAbility = classData.spellAbility || "str";
             
             const classInfo = {
                 keyAbilityMod: data.abilities[keyAbilityScore].mod,
                 levels: classData.levels,
                 keyAbilityScore: keyAbilityScore,
                 skillRanksPerLevel: classData.skillRanks.value,
-                isCaster: classData.isCaster
+                isCaster: classData.isCaster,
+				spellAbility: spellAbility
             };
             
             data.classes[className] = classInfo;

--- a/src/module/rules/actions/actor/calculate-classes.js
+++ b/src/module/rules/actions/actor/calculate-classes.js
@@ -11,7 +11,7 @@ export default function (engine) {
 
             const className = cls.name.slugify({replacement: "_", strict: true});
             const keyAbilityScore = classData.kas || "str";
-			const spellAbility = classData.spellAbility || "cha";
+            const spellAbility = classData.spellAbility || "cha";
 			// Default to cha in order for Spell-like abilities to work correctly out of the box
             
             const classInfo = {
@@ -20,7 +20,7 @@ export default function (engine) {
                 keyAbilityScore: keyAbilityScore,
                 skillRanksPerLevel: classData.skillRanks.value,
                 isCaster: classData.isCaster,
-				spellAbility: spellAbility
+                spellAbility: spellAbility
             };
             
             data.classes[className] = classInfo;

--- a/src/module/rules/actions/actor/calculate-classes.js
+++ b/src/module/rules/actions/actor/calculate-classes.js
@@ -11,7 +11,8 @@ export default function (engine) {
 
             const className = cls.name.slugify({replacement: "_", strict: true});
             const keyAbilityScore = classData.kas || "str";
-			const spellAbility = classData.spellAbility || "str";
+			const spellAbility = classData.spellAbility || "cha";
+			// Default to cha in order for Spell-like abilities to work correctly out of the box
             
             const classInfo = {
                 keyAbilityMod: data.abilities[keyAbilityScore].mod,

--- a/src/module/rules/actions/item/calculate-save-dc.js
+++ b/src/module/rules/actions/item/calculate-save-dc.js
@@ -21,7 +21,7 @@ export default function (engine) {
                     const ownerKeyAbilityId = actorData?.attributes.keyability;
                     const itemKeyAbilityId = data.ability;
                     const spellbookSpellAbility = actorData?.attributes.spellcasting
-                    const classSpellAbility = classes.filter(item => item.key === "technomancer" || "mystic" || "witchwarper" || "precog")[0].data.data.spellAbility;
+                    const classSpellAbility = classes.filter(item => item.key === "technomancer" || "mystic" || "witchwarper" || "precog")[0]?.data.data.spellAbility;
 
                     const abilityKey = itemKeyAbilityId || classSpellAbility || spellbookSpellAbility || ownerKeyAbilityId;
                     if (abilityKey) {

--- a/src/module/rules/actions/item/calculate-save-dc.js
+++ b/src/module/rules/actions/item/calculate-save-dc.js
@@ -19,8 +19,9 @@ export default function (engine) {
                 if (!dcFormula) {
                     const ownerKeyAbilityId = actorData?.attributes.keyability;
                     const itemKeyAbilityId = data.ability;
+					const spellAbility = actorData?.attributes.spellcasting
 
-                    const abilityKey = itemKeyAbilityId || ownerKeyAbilityId;
+                    const abilityKey = itemKeyAbilityId || spellAbility || ownerKeyAbilityId;
                     if (abilityKey) {
                         if (itemData.type === "spell") {
                             dcFormula = `10 + @item.level + @owner.abilities.${abilityKey}.mod`;
@@ -33,7 +34,7 @@ export default function (engine) {
                                 }
                             }
                         } else if (itemData.type === "feat") {
-                            dcFormula = `10 + @owner.details.level.value + @owner.abilities.${abilityKey}.mod`;
+                            dcFormula = `10 + floor(@owner.details.level.value / 2) + @owner.abilities.${abilityKey}.mod`;
                         } else {
                             dcFormula = `10 + floor(@item.level / 2) + @owner.abilities.${abilityKey}.mod`;
                         }

--- a/src/module/rules/actions/item/calculate-save-dc.js
+++ b/src/module/rules/actions/item/calculate-save-dc.js
@@ -9,7 +9,7 @@ export default function (engine) {
 
         const actor = fact.owner.actor;
         const actorData = fact.owner.actorData;
-		const classes = actor.items.filter(item => item.type === "class")
+        const classes = actor.items.filter(item => item.type === "class")
 
         if (data.actionType) {
 
@@ -20,10 +20,10 @@ export default function (engine) {
                 if (!dcFormula) {
                     const ownerKeyAbilityId = actorData?.attributes.keyability;
                     const itemKeyAbilityId = data.ability;
-					const SpellbookSpellAbility = actorData?.attributes.spellcasting
-					const classSpellAbility = classes.filter(item => item.key === "technomancer" || "mystic" || "witchwarper" || "precog")[0].data.data.spellAbility;
+                    const spellbookSpellAbility = actorData?.attributes.spellcasting
+                    const classSpellAbility = classes.filter(item => item.key === "technomancer" || "mystic" || "witchwarper" || "precog")[0].data.data.spellAbility;
 
-                    const abilityKey = itemKeyAbilityId || classSpellAbility || SpellbookSpellAbility || ownerKeyAbilityId;
+                    const abilityKey = itemKeyAbilityId || classSpellAbility || spellbookSpellAbility || ownerKeyAbilityId;
                     if (abilityKey) {
                         if (itemData.type === "spell") {
                             dcFormula = `10 + @item.level + @owner.abilities.${abilityKey}.mod`;

--- a/src/module/rules/actions/item/calculate-save-dc.js
+++ b/src/module/rules/actions/item/calculate-save-dc.js
@@ -9,6 +9,7 @@ export default function (engine) {
 
         const actor = fact.owner.actor;
         const actorData = fact.owner.actorData;
+		const classes = actor.items.filter(item => item.type === "class")
 
         if (data.actionType) {
 
@@ -19,9 +20,10 @@ export default function (engine) {
                 if (!dcFormula) {
                     const ownerKeyAbilityId = actorData?.attributes.keyability;
                     const itemKeyAbilityId = data.ability;
-					const spellAbility = actorData?.attributes.spellcasting
+					const SpellbookSpellAbility = actorData?.attributes.spellcasting
+					const classSpellAbility = classes.filter(item => item.key === "technomancer" || "mystic" || "witchwarper" || "precog")[0].data.data.spellAbility;
 
-                    const abilityKey = itemKeyAbilityId || spellAbility || ownerKeyAbilityId;
+                    const abilityKey = itemKeyAbilityId || classSpellAbility || SpellbookSpellAbility || ownerKeyAbilityId;
                     if (abilityKey) {
                         if (itemData.type === "spell") {
                             dcFormula = `10 + @item.level + @owner.abilities.${abilityKey}.mod`;

--- a/src/template.json
+++ b/src/template.json
@@ -137,7 +137,7 @@
                     "biography": {
                         "value": "",
                         "public": "",
-                        "fullBodyImage": "systems/sfrpg/images/mystery-body.png",
+                        "fullBodyImage": "systems/sfrpg/images/mystery-body.webp",
                         "dateOfBirth": "",
                         "age": 0,
                         "height": "",
@@ -1482,6 +1482,7 @@
             "ref": "fast",
             "will": "slow",
             "isCaster": false,
+			"spellAbility" : "",
             "spellsKnown": {
                 "1":  {"0": 4, "1": 2, "2": null, "3": null, "4": null, "5": null, "6": null},
                 "2":  {"0": 5, "1": 3, "2": null, "3": null, "4": null, "5": null, "6": null},

--- a/src/template.json
+++ b/src/template.json
@@ -1482,7 +1482,7 @@
             "ref": "fast",
             "will": "slow",
             "isCaster": false,
-			"spellAbility" : "",
+            "spellAbility" : "",
             "spellsKnown": {
                 "1":  {"0": 4, "1": 2, "2": null, "3": null, "4": null, "5": null, "6": null},
                 "2":  {"0": 5, "1": 3, "2": null, "3": null, "4": null, "5": null, "6": null},

--- a/src/templates/items/class.html
+++ b/src/templates/items/class.html
@@ -138,11 +138,11 @@
                     </label>
                 </div>
             </div>
-			
-			
+            
+            
 
             {{#if itemData.isCaster}}
-			<div class="form-group">
+            <div class="form-group">
                 <label>{{localize "SFRPG.ClassSpellcastingAbility"}}</label>
                 <div class="form-fields">
                     <select name="data.spellAbility">
@@ -154,8 +154,8 @@
                     </select>
                 </div>
             </div>
-			
-			
+            
+            
             <div class="form-group" style="align-items: flex-start;">
                 <label>{{localize "SFRPG.ItemSheet.Class.SpellCasting.SpellsKnown"}}</label>
                 <table class="spells-known" cellpadding="5">

--- a/src/templates/items/class.html
+++ b/src/templates/items/class.html
@@ -143,7 +143,7 @@
 
             {{#if itemData.isCaster}}
 			<div class="form-group">
-                <label>{{localize "SFRPG.ClassKeyAbilityScore"}}</label>
+                <label>{{localize "SFRPG.ClassSpellcastingAbility"}}</label>
                 <div class="form-fields">
                     <select name="data.spellAbility">
                         {{#select itemData.spellAbility}}

--- a/src/templates/items/class.html
+++ b/src/templates/items/class.html
@@ -138,8 +138,24 @@
                     </label>
                 </div>
             </div>
+			
+			
 
             {{#if itemData.isCaster}}
+			<div class="form-group">
+                <label>{{localize "SFRPG.ClassKeyAbilityScore"}}</label>
+                <div class="form-fields">
+                    <select name="data.spellAbility">
+                        {{#select itemData.spellAbility}}
+                        {{#each config.abilities as |name val|}}
+                        <option value="{{val}}">{{name}}</option>
+                        {{/each}}
+                        {{/select}}
+                    </select>
+                </div>
+            </div>
+			
+			
             <div class="form-group" style="align-items: flex-start;">
                 <label>{{localize "SFRPG.ItemSheet.Class.SpellCasting.SpellsKnown"}}</label>
                 <table class="spells-known" cellpadding="5">


### PR DESCRIPTION
Currently, spell DCs always default's to your key ability score. This merge incorporates the dropdown into the calculation, allowing Precogs to have an easy method of setting their spellcasting, instead of manually changing every spell. The priority is:

1.  The ability set in the spell
2.  The ability set in the spellcasting dropdown
3.  The class's key ability score

Also set the default save DC of feats to half level rather than full level as that is usually the default for class features.