### PR TITLE
Scaling Cantrips variant rule

### DIFF
--- a/src/items/spells/energy_ray.json
+++ b/src/items/spells/energy_ray.json
@@ -93,6 +93,10 @@
       "dc": "",
       "descriptor": "negate"
     },
+    "scaling": {
+      "d3": true,
+      "d6": false
+    },
     "school": "con",
     "source": "CRB pg. 353",
     "sr": true,

--- a/src/items/spells/hazard.json
+++ b/src/items/spells/hazard.json
@@ -92,6 +92,10 @@
       "dc": "",
       "descriptor": "negate"
     },
+    "scaling": {
+      "d3": true,
+      "d6": false
+    },
     "school": "evo",
     "source": "COM pg. 136",
     "sr": true,

--- a/src/items/spells/injury_echo.json
+++ b/src/items/spells/injury_echo.json
@@ -94,6 +94,10 @@
       "dc": "",
       "descriptor": "negate"
     },
+    "scaling": {
+      "d3": false,
+      "d6": true
+    },
     "school": "trs",
     "source": "GM pg. 76",
     "sr": true,

--- a/src/items/spells/telekinetic_projectile.json
+++ b/src/items/spells/telekinetic_projectile.json
@@ -78,6 +78,10 @@
       "dc": null,
       "descriptor": "negate"
     },
+    "scaling": {
+      "d3": false,
+      "d6": true
+    },
     "school": "evo",
     "source": "CRB pg. 380",
     "sr": false,

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1958,7 +1958,7 @@
                 "Name": "Enable Galactic Trade"
             },
             "ScalingCantrips": {
-                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Changing this setting will alter the formulas of all affected spells on all actors, so can take a while if you have lots.",
                 "Name": "Enable Scaling Cantrips"
             },
             "StarshipActionsCrit": {

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1957,6 +1957,10 @@
                 "Hint": "Enables the Galactic Trade subsystem, allowing the maximum BP on a ship to be 5% higher than normal, and adds BPs to the ship inventory as credits.",
                 "Name": "Enable Galactic Trade"
             },
+            "ScalingCantrips": {
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Name": "Enable Scaling Cantrips"
+            },
             "StarshipActionsCrit": {
                 "Hint": "Display state for the critical effect of starship actions.",
                 "Name": "Starship Actions Critical Effect",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1958,7 +1958,7 @@
                 "Name": "Enable Galactic Trade"
             },
             "ScalingCantrips": {
-                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Changing this setting will alter the formulas of all affected spells on all actors, so can take a while if you have lots.",
                 "Name": "Enable Scaling Cantrips"
             },
             "StarshipActionsCrit": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1957,6 +1957,10 @@
                 "Hint": "Enables the Galactic Trade subsystem, allowing the maximum BP on a ship to be 5% higher than normal, and adds BPs to the ship inventory as credits.",
                 "Name": "Enable Galactic Trade"
             },
+            "ScalingCantrips": {
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Name": "Enable Scaling Cantrips"
+            },
             "StarshipActionsCrit": {
                 "Hint": "Display state for the critical effect of starship actions.",
                 "Name": "Starship Actions Critical Effect",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1958,7 +1958,7 @@
                 "Name": "Activer le commerce galactique"
             },
             "ScalingCantrips": {
-                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Changing this setting will alter the formulas of all affected spells on all actors, so can take a while if you have lots.",
                 "Name": "Enable Scaling Cantrips"
             },
             "StarshipActionsCrit": {

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1957,6 +1957,10 @@
                 "Hint": "Active le sous-système de commerce galactique, ce qui permet d'augmenter de 5 % le nombre maximal de BP d'un navire et d'ajouter des BP à l'inventaire du navire sous forme de crédits.",
                 "Name": "Activer le commerce galactique"
             },
+            "ScalingCantrips": {
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Name": "Enable Scaling Cantrips"
+            },
             "StarshipActionsCrit": {
                 "Hint": "État d'affichage pour l'effet critique des actions des vaisseaux spatiaux.",
                 "Name": "Effets critiques des actions de vaisseaux spatiaux",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -1958,7 +1958,7 @@
                 "Name": "Enable Galactic Trade"
             },
             "ScalingCantrips": {
-                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Changing this setting will alter the formulas of all affected spells on all actors, so can take a while if you have lots.",
                 "Name": "Enable Scaling Cantrips"
             },
             "StarshipActionsCrit": {

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -1957,6 +1957,10 @@
                 "Hint": "Enables the Galactic Trade subsystem, allowing the maximum BP on a ship to be 5% higher than normal, and adds BPs to the ship inventory as credits.",
                 "Name": "Enable Galactic Trade"
             },
+            "ScalingCantrips": {
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Name": "Enable Scaling Cantrips"
+            },
             "StarshipActionsCrit": {
                 "Hint": "Visualizza lo stato per l'effetto critico delle azioni delle astronavi.",
                 "Name": "Effetti critici delle azioni delle astronavi",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -1958,7 +1958,7 @@
                 "Name": "Enable Galactic Trade"
             },
             "ScalingCantrips": {
-                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Changing this setting will alter the formulas of all affected spells on all actors, so can take a while if you have lots.",
                 "Name": "Enable Scaling Cantrips"
             },
             "StarshipActionsCrit": {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -1957,6 +1957,10 @@
                 "Hint": "Enables the Galactic Trade subsystem, allowing the maximum BP on a ship to be 5% higher than normal, and adds BPs to the ship inventory as credits.",
                 "Name": "Enable Galactic Trade"
             },
+            "ScalingCantrips": {
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Name": "Enable Scaling Cantrips"
+            },
             "StarshipActionsCrit": {
                 "Hint": "Display state for the critical effect of starship actions.",
                 "Name": "Starship Actions Critical Effect",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -1958,7 +1958,7 @@
                 "Name": "Habilitar Comércio Galáctico"
             },
             "ScalingCantrips": {
-                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Changing this setting will alter the formulas of all affected spells on all actors, so can take a while if you have lots.",
                 "Name": "Enable Scaling Cantrips"
             },
             "StarshipActionsCrit": {

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -1957,6 +1957,10 @@
                 "Hint": "Habilita o subsistema de Comércio Galáctico, permitindo que o PF máximo em uma espaçonave seja 5% maior do que o normal, e adiciona PFs ao estoque da espaçonave como créditos.",
                 "Name": "Habilitar Comércio Galáctico"
             },
+            "ScalingCantrips": {
+                "Hint": "Enables the Scaling Cantrips variant rule from Galactic Magic pg. 88. Affected spells must be re-added from the compendium for this setting to take effect.",
+                "Name": "Enable Scaling Cantrips"
+            },
             "StarshipActionsCrit": {
                 "Hint": "Estado de exibição para o efeito crítico das ações da nave.",
                 "Name": "Efeito crítico das ações da espaçonave",

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1111,14 +1111,14 @@ export class ActorSheetSFRPG extends ActorSheet {
                         return existingClass;
                     }
                 }
-                
-                if (game.settings.get('sfrpg','scalingCantrips') && sidebarItem.type === "spell") {
-                _onScalingCantripDrop(sidebarItem);
-                }
 
                 const addedItemResult = await targetActor.createItem(duplicate(sidebarItem.data));
                 if (addedItemResult.length > 0) {
                     const addedItem = targetActor.getItem(addedItemResult[0].id);
+                    
+                    if (game.settings.get('sfrpg','scalingCantrips') && sidebarItem.type === "spell") {
+                        _onScalingCantripDrop(addedItem);
+                    }
 
                     if (targetContainer) {
                         let newContents = [];

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -10,6 +10,7 @@ import { ItemDeletionDialog } from "../../apps/item-deletion-dialog.js"
 import { InputDialog } from "../../apps/input-dialog.js"
 import { SFRPG } from "../../config.js";
 
+import { _onScalingCantripDrop } from "../../item/item.js";
 /**
  * Extend the basic ActorSheet class to do all the SFRPG things!
  * This sheet is an Abstract layer which is not used.
@@ -1031,7 +1032,11 @@ export class ActorSheetSFRPG extends ActorSheet {
 
             const createResult = await targetActor.createItem(itemData.data._source);
             const addedItem = targetActor.getItem(createResult[0].id);
-
+            
+            if (game.settings.get('sfrpg','scalingCantrips') && addedItem.type === "spell") {
+                _onScalingCantripDrop(addedItem);
+            }
+                
             if (!(addedItem.type in SFRPG.containableTypes)) {
                 targetContainer = null;
             }
@@ -1105,6 +1110,10 @@ export class ActorSheetSFRPG extends ActorSheet {
                         existingClass.update(levelUpdate)
                         return existingClass;
                     }
+                }
+                
+                if (game.settings.get('sfrpg','scalingCantrips') && sidebarItem.type === "spell") {
+                _onScalingCantripDrop(sidebarItem);
                 }
 
                 const addedItemResult = await targetActor.createItem(duplicate(sidebarItem.data));

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1623,7 +1623,7 @@ export async function _onScalingCantripsSettingChanges() {
                 
                 delete currentValue.scaling;
             }
-        await actor.updateEmbeddedDocuments("Item", updates);             
+        await actor.updateEmbeddedDocuments("Item", updates);
         count += params.length;
         }
     }

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1665,4 +1665,16 @@ export async function scalingCantrips() {
         console.log("Starfinder | Updated " + updated + " spells to", ((setting) ? "scaling formulas." : "their default formulas."));
     }
 }
-    
+export async function _onScalingCantripDrop(addedItem) {
+    if (addedItem.data.data.scaling?.d3) { 
+        const updates = addedItem.data.data.damage.parts;
+        updates[0].formula = "lookupRange(@details.cl.value, 1, 7, 2, 10, 3, 13, 4, 15, 5, 17, 7, 19, 9)d(lookupRange(@details.cl.value, 3, 7, 4)) + lookupRange(@details.cl.value, 0, 3, floor(@details.level.value/2))";
+        await addedItem.update({"data.damage.parts": updates});
+        console.log(`Starfinder | Updated ${addedItem.name} to use the d3 scaling formula.`);
+    } else if (addedItem.data.data.scaling?.d6) {
+        const updates = addedItem.data.data.damage.parts;
+        updates[0].formula = "lookupRange(@details.cl.value, 1, 7, 2, 10, 3, 13, 4, 15, 5, 17, 7, 19, 9)d6 + lookupRange(@details.cl.value, 0, 3, floor(@details.level.value/2))";
+        await addedItem.update({"data.damage.parts": updates});
+        console.log(`Starfinder | Updated ${addedItem.name} to use the d6 scaling formula.`);
+    }  
+}

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1666,7 +1666,7 @@ export async function scalingCantrips() {
         }
         
         if (updated) {
-        console.log("Updated " + updated + " spells to", ((setting) ? "scaling formulas." : "their default formulas."))
+        console.log("Starfinder | Updated " + updated + " spells to", ((setting) ? "scaling formulas." : "their default formulas."))
         }
     }
     

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1622,8 +1622,8 @@ export async function _onScalingCantripsSettingChanges() {
                 }
                 
                 delete currentValue.scaling;
-                await actor.updateEmbeddedDocuments("Item", updates);
-                }
+            }
+        await actor.updateEmbeddedDocuments("Item", updates);             
         count += params.length;
         }
     }

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1601,72 +1601,72 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 }
 
 export async function scalingCantrips() {
-        let spells = ['Hazard','Energy Ray','Telekinetic Projectile','Injury Echo']
-        let pack = game.packs.get('sfrpg.spells')
-        let d3scaling = "lookupRange(@details.cl.value, 1d3, 3, 1d3+floor(@details.level.value/2), 7, 2d4+floor(@details.level.value/2), 10, 3d4+floor(@details.level.value/2), 13, 4d4+floor(@details.level.value/2), 15, 5d4+floor(@details.level.value/2), 17, 7d4+floor(@details.level.value/2), 19, 9d4+floor(@details.level.value/2))"
-        let d6scaling = "lookupRange(@details.cl.value, 1d6, 3, 1d6+floor(@details.level.value/2), 7, 2d6+floor(@details.level.value/2), 10, 3d6+floor(@details.level.value/2), 13, 4d6+floor(@details.level.value/2), 15, 5d6+floor(@details.level.value/2), 17, 7d6+floor(@details.level.value/2), 19, 9d6+floor(@details.level.value/2))"
-        let wasLocked = pack.locked
-        let setting = (game.settings.get("sfrpg", "scalingCantrips"))
-        let updated = 0
+    let spells = ['Hazard','Energy Ray','Telekinetic Projectile','Injury Echo']
+    let pack = game.packs.get('sfrpg.spells')
+    let d3scaling = "lookupRange(@details.cl.value, 1, 7, 2, 10, 3, 13, 4, 15, 5, 17, 7, 19, 9)d(lookupRange(@details.cl.value, 3, 7, 4)) + lookupRange(@details.cl.value, 0, 3, floor(@details.level.value/2))"
+    let d6scaling = "lookupRange(@details.cl.value, 1, 7, 2, 10, 3, 13, 4, 15, 5, 17, 7, 19, 9)d6 + lookupRange(@details.cl.value, 0, 3, floor(@details.level.value/2))"
+    let wasLocked = pack.locked
+    let setting = (game.settings.get("sfrpg", "scalingCantrips"))
+    let updated = 0
 
-        if (wasLocked) {
-            await pack.configure({ locked: false });
+    if (wasLocked) {
+        await pack.configure({ locked: false });
+    }
+
+    let compIndex = await pack.index || getIndex()
+
+
+    let spellsFull = spells.map( async (currentValue, index, arr) => {
+        let filter = await compIndex.filter(i => i.name === spells[index])
+        return await pack.getDocument(filter[0]._id)
+
+    })
+
+    spellsFull = await Promise.all(spellsFull)
+    
+    for (let x of spellsFull) {
+        let updates = duplicate(x.data.data.damage.parts)
+    
+    if (setting) {
+        switch (x.data.data.damage.parts[0].formula) {
+            
+            case "1d3":
+                updates[0].formula = d3scaling
+                await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
+                updated += 1
+            break;
+
+            case "1d6":
+                updates[0].formula = d6scaling
+                await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
+                updated += 1
+            break;
         }
+    } else {
+        switch (x.data.data.damage.parts[0].formula) {
+            case d3scaling:
+                updates[0].formula = "1d3"
+                await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
+                updated += 1
+            break;
 
-        let compIndex = await pack.index || getIndex()
-
-
-        let spellsFull = spells.map( async (currentValue, index, arr) => {
-            let filter = await compIndex.filter(i => i.name === spells[index])
-            return await pack.getDocument(filter[0]._id)
-
-        })
-
-        spellsFull = await Promise.all(spellsFull)
-        
-        for (let x of spellsFull) {
-            let updates = duplicate(x.data.data.damage.parts)
-        
-        if (setting) {
-            switch (x.data.data.damage.parts[0].formula) {
-                
-                case "1d3":
-                    updates[0].formula = d3scaling
-                    await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
-                    updated += 1
-                break;
-
-                case "1d6":
-                    updates[0].formula = d6scaling
-                    await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
-                    updated += 1
-                break;
-            }
-        } else {
-            switch (x.data.data.damage.parts[0].formula) {
-                case d3scaling:
-                    updates[0].formula = "1d3"
-                    await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
-                    updated += 1
-                break;
-
-                case d6scaling:
-                   updates[0].formula = "1d6"
-                    await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
-                    updated += 1
-                break
-            }
+            case d6scaling:
+               updates[0].formula = "1d6"
+                await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
+                updated += 1
+            break
         }
+    }
 
 
-        }
+    }
 
-        if (wasLocked) {
-            await pack.configure({ locked: true });
-        }
-        
-        if (updated) {
-        console.log("Starfinder | Updated " + updated + " spells to", ((setting) ? "scaling formulas." : "their default formulas."))
-        }
+    if (wasLocked) {
+        await pack.configure({ locked: true });
+    }
+    
+    if (updated) {
+    console.log("Starfinder | Updated " + updated + " spells to", ((setting) ? "scaling formulas." : "their default formulas."))
+    }
     }
     

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1601,72 +1601,68 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 }
 
 export async function scalingCantrips() {
-    let spells = ['Hazard','Energy Ray','Telekinetic Projectile','Injury Echo']
-    let pack = game.packs.get('sfrpg.spells')
-    let d3scaling = "lookupRange(@details.cl.value, 1, 7, 2, 10, 3, 13, 4, 15, 5, 17, 7, 19, 9)d(lookupRange(@details.cl.value, 3, 7, 4)) + lookupRange(@details.cl.value, 0, 3, floor(@details.level.value/2))"
-    let d6scaling = "lookupRange(@details.cl.value, 1, 7, 2, 10, 3, 13, 4, 15, 5, 17, 7, 19, 9)d6 + lookupRange(@details.cl.value, 0, 3, floor(@details.level.value/2))"
-    let wasLocked = pack.locked
-    let setting = (game.settings.get("sfrpg", "scalingCantrips"))
-    let updated = 0
+    const spells = ['Hazard', 'Energy Ray', 'Telekinetic Projectile', 'Injury Echo'];
+    const pack = game.packs.get('sfrpg.spells');
+    const d3scaling = "lookupRange(@details.cl.value, 1, 7, 2, 10, 3, 13, 4, 15, 5, 17, 7, 19, 9)d(lookupRange(@details.cl.value, 3, 7, 4)) + lookupRange(@details.cl.value, 0, 3, floor(@details.level.value/2))";
+    const d6scaling = "lookupRange(@details.cl.value, 1, 7, 2, 10, 3, 13, 4, 15, 5, 17, 7, 19, 9)d6 + lookupRange(@details.cl.value, 0, 3, floor(@details.level.value/2))"
+    const wasLocked = pack.locked;
+    const setting = (game.settings.get("sfrpg", "scalingCantrips"));
+    let updated = 0;
 
     if (wasLocked) {
-        await pack.configure({ locked: false });
+        await pack.configure({locked: false});
     }
 
-    let compIndex = await pack.index || getIndex()
+    const compIndex = await pack.index || getIndex();
 
-
-    let spellsFull = spells.map( async (currentValue, index, arr) => {
-        let filter = await compIndex.filter(i => i.name === spells[index])
-        return await pack.getDocument(filter[0]._id)
-
+    let spellsFull = spells.map(async(currentValue, index, arr) => {
+        let filter = await compIndex.filter(i => i.name === spells[index]);
+        return await pack.getDocument(filter[0]._id);
     })
 
-    spellsFull = await Promise.all(spellsFull)
-    
+    spellsFull = await Promise.all(spellsFull);
+
     for (let x of spellsFull) {
-        let updates = duplicate(x.data.data.damage.parts)
-    
-    if (setting) {
-        switch (x.data.data.damage.parts[0].formula) {
-            
-            case "1d3":
-                updates[0].formula = d3scaling
-                await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
-                updated += 1
-            break;
+        let updates = duplicate(x.data.data.damage.parts);
 
-            case "1d6":
-                updates[0].formula = d6scaling
-                await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
-                updated += 1
-            break;
+        if (setting) {
+            switch (x.data.data.damage.parts[0].formula) {
+
+                case "1d3":
+                    updates[0].formula = d3scaling;
+                    await x.update({"data.damage.parts": updates}, {pack: "sfrpg.spells"});
+                    updated += 1;
+                    break;
+
+                case "1d6":
+                    updates[0].formula = d6scaling;
+                    await x.update({"data.damage.parts": updates}, {pack: "sfrpg.spells"});
+                    updated += 1;
+                    break;
+            }
+        } else {
+            switch (x.data.data.damage.parts[0].formula) {
+                case d3scaling:
+                    updates[0].formula = "1d3";
+                    await x.update({"data.damage.parts": updates}, {pack: "sfrpg.spells"});
+                    updated += 1;
+                    break;
+
+                case d6scaling:
+                    updates[0].formula = "1d6";
+                    await x.update({"data.damage.parts": updates}, {pack: "sfrpg.spells"});
+                    updated += 1;
+                    break;
+            }
         }
-    } else {
-        switch (x.data.data.damage.parts[0].formula) {
-            case d3scaling:
-                updates[0].formula = "1d3"
-                await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
-                updated += 1
-            break;
-
-            case d6scaling:
-               updates[0].formula = "1d6"
-                await x.update( {"data.damage.parts": updates}, {pack: "sfrpg.spells"})
-                updated += 1
-            break
-        }
-    }
-
-
     }
 
     if (wasLocked) {
-        await pack.configure({ locked: true });
+        await pack.configure({locked: true});
     }
-    
+
     if (updated) {
-    console.log("Starfinder | Updated " + updated + " spells to", ((setting) ? "scaling formulas." : "their default formulas."))
+        console.log("Starfinder | Updated " + updated + " spells to", ((setting) ? "scaling formulas." : "their default formulas."));
     }
-    }
+}
     

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -103,7 +103,7 @@ export const registerSystemSettings = function () {
     default: false,
     type: Boolean,
     onChange: () => {
-        scalingCantrips() 
+        //scalingCantrips() 
     }
 });    
 

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -1,4 +1,5 @@
 import { SFRPG } from "./config.js";
+import { scalingCantrips ) from "./module/item/item.js";
 
 export const registerSystemSettings = function () {
     game.settings.register("sfrpg", "diagonalMovement", {
@@ -93,6 +94,18 @@ export const registerSystemSettings = function () {
         default: false,
         type: Boolean
     });
+    
+    game.settings.register("sfrpg", "scalingCantrips", {
+    name: "SFRPG.Settings.ScalingCantrips.Name",
+        hint: "SFRPG.Settings.ScalingCantrips.Hint",
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean,
+    onChange: () => {
+        scalingCantrips() 
+    }
+});    
 
     for (let combatType of SFRPG.combatTypes) {
         const capitalizedCombatType = combatType[0].toUpperCase() + combatType.slice(1);

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -1,5 +1,5 @@
 import { SFRPG } from "./config.js";
-import { scalingCantrips } from "./item/item.js";
+import { _onScalingCantripsSettingChanges } from "./item/item.js";
 
 export const registerSystemSettings = function () {
     game.settings.register("sfrpg", "diagonalMovement", {
@@ -103,7 +103,7 @@ export const registerSystemSettings = function () {
     default: false,
     type: Boolean,
     onChange: () => {
-        //scalingCantrips() 
+        _onScalingCantripsSettingChanges() 
     }
 });    
 

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -1,5 +1,5 @@
 import { SFRPG } from "./config.js";
-import { scalingCantrips ) from "./module/item/item.js";
+import { scalingCantrips } from "./item/item.js";
 
 export const registerSystemSettings = function () {
     game.settings.register("sfrpg", "diagonalMovement", {


### PR DESCRIPTION
Feeling productive this week! 😁

Added a system setting to enable scaling cantrips. Upon enabling, it'll edit the affected spells in the spells compendium.

I was going to add a check to startup to ensure the setting is being followed, but I was concerned about init times so I left that out, let me know if I should pursue that.

The formula used is admittedly a really ugly lookupRange one, I'll see if I can make a non-lookupRange one, but it'll still be a bit ugly. At least when expanded, a non-lookupRange formula won't show *all* the dice.

Also I just put the function in item.js, let me know if there's a better place for it.