### PR TITLE
Fix applying damage to starships throwing an error

### DIFF
--- a/src/module/actor/mixins/actor-damage.js
+++ b/src/module/actor/mixins/actor-damage.js
@@ -1,4 +1,5 @@
 import { SFRPG } from "../../config.js";
+import { ChoiceDialog } from "../../apps/choice-dialog.js";
 
 export class SFRPGHealingSetting {
     constructor() {


### PR DESCRIPTION
Currently applying damage to a starship throws an error, saying ChoiceDialog is undefined. Adding an import fixes that and it behaves as expected.