### PR TITLE
Remove solarian attunement from special traits

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -841,6 +841,7 @@
         "FeaturesUsage": "Verbrauch",
         "FlagDeprecationNotice": "<strong>ANMERKUNG:</strong> Diese Werte werden durch das neue Modifikatorensystem ersetzt und in einer zukünftigen Version entfernt. Es wird empfohlen, diese Werte abzuwählen und sie als Modifikatoren auf der Registerkarte 'Modifikatoren' hinzuzufügen.",
         "FlagsInstructions": "Konfiguriere die Charakterzüge und -eigenschaften, die das Verhalten des Starfinder-Systems feiner abstimmen.",
+        "FlagsEmptySolarian": "There are no special traits at the moment. If you're looking for Solarian Attunement, use the new Actor Resource system within the Stellar Mode class feature.",
         "FlagsSave": "Spezielle Merkmale aktualisieren",
         "FlagsTitle": "Spezielle Merkmale konfigurieren",
         "FortitudeSave": "Zähigkeit",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -842,6 +842,7 @@
         "FeaturesUsage": "Usage",
         "FlagDeprecationNotice": "<strong>NOTE:</strong> These values are being replaced by the new modifiers system and will be removed in a future update. It is recommended that you uncheck any of these values and add them as a modifer on the Modifiers tab.",
         "FlagsInstructions": "Configure character features and traits which fine-tune behaviors of the Starfinder system.",
+        "FlagsEmptySolarian": "There are no special traits at the moment. If you're looking for Solarian Attunement, use the new Actor Resource system within the Stellar Mode class feature.",
         "FlagsSave": "Update Special Traits",
         "FlagsTitle": "Configure Special Traits",
         "FortitudeSave": "Fortitude",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -841,6 +841,7 @@
         "FeaturesUsage": "Utilisation",
         "FlagDeprecationNotice": "<strong>REMARQUE:</strong> ces valeurs sont remplacées par le nouveau système de modificateurs et seront supprimées lors d'une prochaine mise à jour. Il est recommandé de décocher l'une de ces valeurs et de les ajouter en tant que modificateur dans l'onglet Modificateurs.",
         "FlagsInstructions": "Configurez les caractéristiques et traits de caractère qui déterminent les comportements du système.",
+        "FlagsEmptySolarian": "There are no special traits at the moment. If you're looking for Solarian Attunement, use the new Actor Resource system within the Stellar Mode class feature.",
         "FlagsSave": "Mettre à jour les traits spéciaux.",
         "FlagsTitle": "Configurer des traits spéciaux.",
         "FortitudeSave": "Vigueur",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -841,6 +841,7 @@
         "FeaturesUsage": "Utilizzi",
         "FlagDeprecationNotice": "<strong>NOTA:</strong> questi valori vengono sostituiti dai nuovi modificatori e il sistema verrà cancellato in un prossimo aggiornamento. Si consiglia di deselezionare uno di questi valori e aggiungerli come Modificatore nella scheda Modificatori.",
         "FlagsInstructions": "Configura le caratteristiche e i Talenti che determinano il comportamento del sistema.",
+        "FlagsEmptySolarian": "There are no special traits at the moment. If you're looking for Solarian Attunement, use the new Actor Resource system within the Stellar Mode class feature.",
         "FlagsSave": "Salvare i Talenti Speciali",
         "FlagsTitle": "Configurazione dei Talenti Speciali.",
         "FortitudeSave": "Tempra",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -841,6 +841,7 @@
         "FeaturesUsage": "用法",
         "FlagDeprecationNotice": "<strong>メモ:</strong> これらの値は新しい修正値システムに置き換えられており、将来のアップデートで削除される予定です。これらの値をオフにして、[状態]タブで修正値として追加することをお勧めします。",
         "FlagsInstructions": "Starfinderシステム上のキャラクター特性を設定する。",
+        "FlagsEmptySolarian": "There are no special traits at the moment. If you're looking for Solarian Attunement, use the new Actor Resource system within the Stellar Mode class feature.",
         "FlagsSave": "例外的特性の更新",
         "FlagsTitle": "例外的特性の設定",
         "FortitudeSave": "頑健",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -841,6 +841,7 @@
         "FeaturesUsage": "Uso",
         "FlagDeprecationNotice": "<strong>NOTA:</strong> Esses valores estão sendo substituídos pelo novo sistema de modificadores e serão removidos em uma atualização futura. É recomendável desmarcar qualquer um desses valores e adicioná-los como um modificador na guia Modificadores.",
         "FlagsInstructions": "Configure as características e traços dos personagens que ajustam os comportamentos do sistema Starfinder.",
+        "FlagsEmptySolarian": "There are no special traits at the moment. If you're looking for Solarian Attunement, use the new Actor Resource system within the Stellar Mode class feature.",
         "FlagsSave": "Atualizar Traços Especiais",
         "FlagsTitle": "ConfigurAR Traços Especiais",
         "FortitudeSave": "Fortitude",

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -1457,7 +1457,7 @@ SFRPG.conditionsCausingFlatFooted = ["blinded", "cowering", "off-kilter", "pinne
 
 // TODO localize
 SFRPG.characterFlags = {
-    "solarianAttunement": {
+    /*"solarianAttunement": {
         name: "Solarian Attunement",
         hint: "You can enabled the management of attenument inside the combat tracker.",
         section: "SFRPG.CharacterFlagsSectionClassFeatures",

--- a/src/templates/apps/actor-flags.html
+++ b/src/templates/apps/actor-flags.html
@@ -28,6 +28,7 @@
     </div>
     {{/each}}
     {{/each}}
+    <p>{{localize 'SFRPG.FlagsEmptySolarian'}}</p>
 
     <button type="submit" name="submit">
         <i class="far fa-save"></i> {{localize 'SFRPG.FlagsSave'}}


### PR DESCRIPTION
Removed solarian attunement from the special traits menu, and added a message to indicate there are no traits currently. 

Alternatively could remove the special traits menu entirely, but that would feel more impactful