### PR TITLE
Fix everyday clothing price

### DIFF
--- a/src/items/equipment/clothing_everyday.json
+++ b/src/items/equipment/clothing_everyday.json
@@ -42,7 +42,7 @@
     "identified": true,
     "level": 1,
     "modifiers": [],
-    "price": 5,
+    "price": 1,
     "quantity": 1,
     "source": "CRB pg. 230"
   },


### PR DESCRIPTION
Hi, small fix for an item : everyday clothing is 1 credit rather than 5.
See Archives of Nethys for reference : https://www.aonsrd.com/OtherItemsDisplay.aspx?ItemName=Everyday&Family=Clothing .
I can confirm that it's the same in the (French) Core Rulebook.

PS: Cooking the equipment db it looks like an item unrelated to this change gets removed : `Tool Kit, SF Armory`. From a quick glance it looks like it's because `Starfinder` is written in full now. Not sure what to do with it so I did not include it in the patch.