### PR TITLE
Clicking a Starship Action expands with the description

### DIFF
--- a/src/less/starship.less
+++ b/src/less/starship.less
@@ -240,7 +240,19 @@
                 .action-image:hover {
                     background-image: url("../../icons/svg/d20-black.svg") !important;
                 }
+                
+                
             }
+            
+            .item-summary {
+                flex: 0 0 100% !important;
+                font-size: 12px;
+                line-height: 18px;
+                padding: 0.25em 0.5em;
+                padding-top: 7px;
+                padding-bottom: 7px;
+                border-top: 1px solid #c9c7b8;
+                }
 
             .action-phase {
                 flex: 2;

--- a/src/less/starship.less
+++ b/src/less/starship.less
@@ -240,7 +240,6 @@
                 .action-image:hover {
                     background-image: url("../../icons/svg/d20-black.svg") !important;
                 }
- 
             }
             
             .item-summary {

--- a/src/less/starship.less
+++ b/src/less/starship.less
@@ -240,8 +240,7 @@
                 .action-image:hover {
                     background-image: url("../../icons/svg/d20-black.svg") !important;
                 }
-                
-                
+ 
             }
             
             .item-summary {

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -630,10 +630,9 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
         const filter = index.filter(i => i.name === (li.prevObject[0].innerHTML));
         const item = await pack.getDocument(filter[0]._id);
         const chatData = item.getChatData({ secrets: this.actor.isOwner, rollData: this.actor.data.data });
-        const critical = (!!chatData.effectCritical);
         
         let content = `<p><strong>${game.i18n.localize("SFRPG.StarshipSheet.Actions.Tooltips.NormalEffect")}:</strong> ${chatData.effectNormal}</p>`;
-        if (critical) {
+        if (chatData.effectCritical) {
             content += `<p><strong>${game.i18n.localize("SFRPG.StarshipSheet.Actions.Tooltips.CriticalEffect")}: </strong> ${chatData.effectCritical}</p>`;
         };
 

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -623,7 +623,7 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
         event.preventDefault();
         
         const pack = game.packs.get('sfrpg.starship-actions');
-        const index = await pack.index || getIndex();
+        const index = pack.index || (await pack.getIndex());
         
         let li = $(event.currentTarget).parents('.action');   
         

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -622,7 +622,7 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
     async _onActionSummary(event) {
         event.preventDefault();
         
-        const actionPack = game.settings.get('sfrpg', 'starshipActionsSource')
+        const actionPack = game.settings.get('sfrpg', 'starshipActionsSource');
         const pack = game.packs.get(actionPack);
         const index = pack.index || (await pack.getIndex());
         

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -627,13 +627,14 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
         
         let li = $(event.currentTarget).parents('.action');   
         
-        const filter = index.filter(i => i.name === (li.prevObject[0].innerHTML))
+        const filter = index.filter(i => i.name === (li.prevObject[0].innerHTML));
         const item = await pack.getDocument(filter[0]._id);
         const chatData = item.getChatData({ secrets: this.actor.isOwner, rollData: this.actor.data.data });
         const critical = (!!chatData.effectCritical);
+        
         let content = `<p><strong>${game.i18n.localize("SFRPG.StarshipSheet.Actions.Tooltips.NormalEffect")}:</strong> ${chatData.effectNormal}</p>`;
         if (critical) {
-        content += `<p><strong>${game.i18n.localize("SFRPG.StarshipSheet.Actions.Tooltips.CriticalEffect")}: </strong> ${chatData.effectCritical}</p>`;
+            content += `<p><strong>${game.i18n.localize("SFRPG.StarshipSheet.Actions.Tooltips.CriticalEffect")}: </strong> ${chatData.effectCritical}</p>`;
         };
 
         if (li.hasClass('expanded')) {

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -622,7 +622,8 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
     async _onActionSummary(event) {
         event.preventDefault();
         
-        const pack = game.packs.get('sfrpg.starship-actions');
+        const actionPack = game.settings.get('sfrpg', 'starshipActionsSource')
+        const pack = game.packs.get(actionPack);
         const index = pack.index || (await pack.getIndex());
         
         let li = $(event.currentTarget).parents('.action');   


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/77904738/165866436-3b9ae551-5483-436d-abe4-bedbc9a25c1b.png)

Currently, Stunt doesn't display the full selections of stunts, but that's a separate underlying issue that currently exists on the Tippy tooltips, but I can address that separately.