### PR TITLE
Skill notes

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -290,6 +290,7 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
             hasArmorCheckPenalty = Boolean(formData.get('hasArmorCheckPenalty')),
             value = Boolean(formData.get('value')) ? 3 : 0,
             misc = Number(formData.get('misc')),
+            notes = String(formData.get('notes')),
             ranks = Number(formData.get('ranks')),
             ability = formData.get('ability'),
             remove = Boolean(formData.get('remove'));
@@ -301,6 +302,7 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
             [`data.skills.${skillId}.ranks`]: ranks,
             [`data.skills.${skillId}.value`]: value,
             [`data.skills.${skillId}.misc`]: misc,
+            [`data.skills.${skillId}.notes`]: notes,
             [`data.skills.${skillId}.isTrainedOnly`]: isTrainedOnly,
             [`data.skills.${skillId}.hasArmorCheckPenalty`]: hasArmorCheckPenalty
         };
@@ -492,7 +494,7 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
             rollContext: rollContext,
             parts: parts,
             title: game.i18n.format("SFRPG.Rolls.Dice.SkillCheckTitle", {skill: CONFIG.SFRPG.skills[skillId.substring(0, 3)]}),
-            flavor: null,
+            flavor: TextEditor.enrichHTML(skill.notes),
             speaker: ChatMessage.getSpeaker({ actor: this }),
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -164,7 +164,7 @@ export class DiceSFRPG {
     static async d20Roll({ event = new Event(''), parts, rollContext, title, speaker, flavor, advantage = true, rollOptions = {},
         critical = 20, fumble = 1, onClose, dialogOptions }) {
 
-        flavor = `${title}${(flavor ? " - " + flavor : "")}`;
+        flavor = `${title}${(flavor ? " <br> " + flavor : "")}`;
         
         if (!rollContext?.isValid()) {
             console.log(['Invalid rollContext', rollContext]);

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -773,7 +773,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             parts: parts,
             rollContext: rollContext,
             title: title,
-            flavor: this.data?.data?.chatFlavor,
+            flavor: TextEditor.enrichHTML(this.data?.data?.chatFlavor),
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             critical: critThreshold,
             rollOptions: rollOptions,
@@ -1087,7 +1087,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             criticalData: itemData.critical,
             rollContext: rollContext,
             title: title,
-            flavor: options?.flavorOverride ?? itemData.chatFlavor,
+            flavor: TextEditor.enrichHTML(options?.flavorOverride) ?? TextEditor.enrichHTML(itemData.chatFlavor),
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             dialogOptions: {
                 width: 400,

--- a/src/templates/apps/add-edit-skill.html
+++ b/src/templates/apps/add-edit-skill.html
@@ -23,6 +23,12 @@
             <input type="number" name="misc" value="{{skill.misc}}" data-dtype="Number" placeholder="0" />
         </div>
     </div>
+    <div class="form-group">
+        <label>Skill Notes</label>
+        <div class="form-fields">
+            <input type="text" name="notes" value="{{skill.notes}}" data-dtype="text" />
+        </div>
+    </div>
     {{#if hasSubName}}
     <div class="form-group">
         <label>Profession Name</label>


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/77904738/167047284-e759673b-5faa-40d9-a0c3-978d121758b8.png)

![image](https://user-images.githubusercontent.com/77904738/167046828-3d5ecb25-8f79-4a94-8a1a-bc7d3f913e3f.png)

I used flavor to implement this rather than the same method as attack's roll notes and damage, just because I couldn't figure out how that worked. Don't think it'll be a major issue in the implementation though.