### PR TITLE
Give archaic weapons -5 damage

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1069,6 +1069,11 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
         /** Create additional modifiers. */
         const additionalModifiers = [];
+        
+        if (itemData.properties?.archaic && isWeapon) {
+            additionalModifiers.push({bonus: { name: game.i18n.format("SFRPG.WeaponPropertiesArchaic"), modifier: "-5", enabled: true, notes: game.i18n.format("SFRPG.WeaponPropertiesArchaicTooltip") } });
+        }
+        
         for (const rolledMod of rolledMods) {
             additionalModifiers.push({
                 bonus: rolledMod


### PR DESCRIPTION
Added a modifier that automatically adds to Archaic weapons that gives a -5 penalty to damage. Defaults to on (under the assumption that *most* enemies will have non-archaic armor), but can easily be toggled off under different circumstances.