### PR TITLE
Fix "undefined" on damage chat card if damage section has no name

### DIFF
--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -696,7 +696,7 @@ export class DiceSFRPG {
                 finalFlavor = tempFlavor;
             }
 
-            if (part) {
+            if (part.name) {
                 finalFlavor += `: ${part.name}`;
                 if (part.partIndex) {
                     finalFlavor += ` (${part.partIndex})`;

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1095,7 +1095,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             criticalData: itemData.critical,
             rollContext: rollContext,
             title: title,
-            flavor: TextEditor.enrichHTML(options?.flavorOverride) ?? TextEditor.enrichHTML(itemData.chatFlavor),
+            flavor: (TextEditor.enrichHTML(options?.flavorOverride) ?? TextEditor.enrichHTML(itemData.chatFlavor)) || null,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             dialogOptions: {
                 width: 400,


### PR DESCRIPTION
Currently, chat cards display an "undefined" on weapons with one damage section if the damage section has no name. This fixes that, and also removes the stray ":" caused by the same circumstances.