### PR TITLE
Migrate container item jsons as to not trip migration

### DIFF
--- a/src/items/equipment/backpack_consumer.json
+++ b/src/items/equipment/backpack_consumer.json
@@ -4,17 +4,6 @@
   "type": "container",
   "data": {
     "type": "",
-    "acceptedItemTypes": {
-      "augmentation": true,
-      "consumable": true,
-      "container": true,
-      "equipment": true,
-      "fusion": true,
-      "goods": true,
-      "technological": true,
-      "upgrade": true,
-      "weapon": true
-    },
     "attuned": false,
     "bulk": "1",
     "container": {
@@ -41,7 +30,6 @@
         }
       ]
     },
-    "contents": [],
     "damage": {
       "parts": []
     },

--- a/src/items/equipment/backpack_industrial.json
+++ b/src/items/equipment/backpack_industrial.json
@@ -4,17 +4,6 @@
   "type": "container",
   "data": {
     "type": "",
-    "acceptedItemTypes": {
-      "augmentation": true,
-      "consumable": true,
-      "container": true,
-      "equipment": true,
-      "fusion": true,
-      "goods": true,
-      "technological": true,
-      "upgrade": true,
-      "weapon": true
-    },
     "attuned": false,
     "bulk": "1",
     "container": {
@@ -41,7 +30,6 @@
         }
       ]
     },
-    "contents": [],
     "damage": {
       "parts": []
     },

--- a/src/items/equipment/null-space_chamber_mk_1.json
+++ b/src/items/equipment/null-space_chamber_mk_1.json
@@ -4,17 +4,6 @@
   "type": "container",
   "data": {
     "type": "",
-    "acceptedItemTypes": {
-      "augmentation": true,
-      "consumable": true,
-      "container": true,
-      "equipment": true,
-      "fusion": true,
-      "goods": true,
-      "technological": true,
-      "upgrade": true,
-      "weapon": true
-    },
     "attuned": false,
     "bulk": "L",
     "container": {
@@ -41,7 +30,6 @@
         }
       ]
     },
-    "contents": [],
     "damage": {
       "parts": []
     },

--- a/src/items/equipment/null-space_chamber_mk_2.json
+++ b/src/items/equipment/null-space_chamber_mk_2.json
@@ -4,17 +4,6 @@
   "type": "container",
   "data": {
     "type": "",
-    "acceptedItemTypes": {
-      "augmentation": true,
-      "consumable": true,
-      "container": true,
-      "equipment": true,
-      "fusion": true,
-      "goods": true,
-      "technological": true,
-      "upgrade": true,
-      "weapon": true
-    },
     "attuned": false,
     "bulk": "L",
     "container": {
@@ -41,7 +30,6 @@
         }
       ]
     },
-    "contents": [],
     "damage": {
       "parts": []
     },

--- a/src/items/equipment/null-space_chamber_mk_3.json
+++ b/src/items/equipment/null-space_chamber_mk_3.json
@@ -4,17 +4,6 @@
   "type": "container",
   "data": {
     "type": "",
-    "acceptedItemTypes": {
-      "augmentation": true,
-      "consumable": true,
-      "container": true,
-      "equipment": true,
-      "fusion": true,
-      "goods": true,
-      "technological": true,
-      "upgrade": true,
-      "weapon": true
-    },
     "attuned": false,
     "bulk": "L",
     "container": {
@@ -41,7 +30,6 @@
         }
       ]
     },
-    "contents": [],
     "damage": {
       "parts": []
     },

--- a/src/items/equipment/starfinder_backpack.json
+++ b/src/items/equipment/starfinder_backpack.json
@@ -4,17 +4,6 @@
   "type": "container",
   "data": {
     "type": "",
-    "acceptedItemTypes": {
-      "augmentation": true,
-      "consumable": true,
-      "container": true,
-      "equipment": true,
-      "fusion": true,
-      "goods": true,
-      "technological": true,
-      "upgrade": true,
-      "weapon": true
-    },
     "attuned": false,
     "bulk": "-",
     "container": {
@@ -41,7 +30,6 @@
         }
       ]
     },
-    "contents": [],
     "damage": {
       "parts": []
     },

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -969,14 +969,13 @@ export class ActorItemHelper {
                 };
 
                 if (item.type === "container") {
-                    const currentStorage = itemData?.container?.storage[0];
                     container.storage.push({
-                        type: currentStorage?.type || "bulk",
-                        subtype: currentStorage?.subtype || "",
-                        amount: currentStorage?.amount || itemData.storageCapacity || 0,
-                        acceptsType: currentStorage?.acceptsType || itemData.acceptedItemTypes ? Object.keys(itemData.acceptedItemTypes) : [],
-                        affectsEncumbrance: (currentStorage?.affectsEncumbrance !== null || undefined) ? (currentStorage?.affectsEncumbrance) : ((itemData.contentBulkMultiplier === 0) ? false : true),
-                        weightProperty: currentStorage?.weightProperty || "bulk"
+                        type: "bulk",
+                        subtype: "",
+                        amount: itemData.storageCapacity || 0,
+                        acceptsType: itemData.acceptedItemTypes ? Object.keys(itemData.acceptedItemTypes) : [],
+                        affectsEncumbrance: itemData.contentBulkMultiplier === 0 ? false : true,
+                        weightProperty: "bulk"
                     });
                 } else if (item.type === "weapon") {
                     container.storage.push({

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -969,13 +969,14 @@ export class ActorItemHelper {
                 };
 
                 if (item.type === "container") {
+                    const currentStorage = itemData?.container?.storage[0];
                     container.storage.push({
-                        type: "bulk",
-                        subtype: "",
-                        amount: itemData.storageCapacity || 0,
-                        acceptsType: itemData.acceptedItemTypes ? Object.keys(itemData.acceptedItemTypes) : [],
-                        affectsEncumbrance: itemData.contentBulkMultiplier === 0 ? false : true,
-                        weightProperty: "bulk"
+                        type: currentStorage?.type || "bulk",
+                        subtype: currentStorage?.subtype || "",
+                        amount: currentStorage?.amount || itemData.storageCapacity || 0,
+                        acceptsType: currentStorage?.acceptsType || itemData.acceptedItemTypes ? Object.keys(itemData.acceptedItemTypes) : [],
+                        affectsEncumbrance: (currentStorage?.affectsEncumbrance !== null || undefined) ? (currentStorage?.affectsEncumbrance) : ((itemData.contentBulkMultiplier === 0) ? false : true),
+                        weightProperty: currentStorage?.weightProperty || "bulk"
                     });
                 } else if (item.type === "weapon") {
                     container.storage.push({

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -964,7 +964,7 @@ export class ActorItemHelper {
                 //console.log(migrate);
 
                 const container = {
-                    contents: (itemData.contents || []).map(x => { return { id: x, index: 0 }; }),
+                    contents: (itemData.container?.contents || itemData.contents || []).map(x => { return { id: x.id, index: 0 }; }),
                     storage: []
                 };
 

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -964,7 +964,7 @@ export class ActorItemHelper {
                 //console.log(migrate);
 
                 const container = {
-                    contents: (itemData.container?.contents || itemData.contents || []).map(x => { return { id: x.id, index: 0 }; }),
+                    contents: (itemData.contents || []).map(x => { return { id: x, index: 0 }; }),
                     storage: []
                 };
 


### PR DESCRIPTION
At the moment, a container migration trips if a container has any of the properties listed on line 955 of `actor-inventory-utils.js`, however, the container items in the compendium have some of those very properties, so I've removed them. 

The migration itself is still a bit problematic, as it doesn't work correctly if the items only have _some_ of the properties (see above 😉), and I may try to rectify that, but at least by changing the compendium JSONs the problem is no longer propagating.