### PR TITLE
Allow actor modifiers to be used in DR

### DIFF
--- a/src/module/rules/actions/actor/calculate-damage-mitigation.js
+++ b/src/module/rules/actions/actor/calculate-damage-mitigation.js
@@ -36,7 +36,7 @@ export default function (engine) {
 
         for (const drModifier of damageReductionModifiers) {
             // TODO: Resolve formula; use RollTree, as it can complete synchronously
-            const resolvedModifierValue = tryResolveModifier(drModifier.modifier, rollContext);
+            const resolvedModifierValue = tryResolveModifier(drModifier.max, rollContext);
             const modifierInfo = {
                 value: resolvedModifierValue,
                 negatedBy: drModifier.valueAffected,


### PR DESCRIPTION
Currently a value such as `@details.level.value` doesn't work with DR (and ER I suppose). Closes #595.