### PR TITLE
Shift clicking a roll with the skip dialog option enabled will show the dialog window

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1987,7 +1987,7 @@
                 "Name": "Use custom Starfinder chat card?"
             },
             "UseQuickRollAsDefault": {
-                "Hint": "When clicking abilities that roll dice, the roll will act as if the Shift key was depressed by default. This will trigger a fast-forwarded roll.",
+                "Hint": "When checked, abilities that roll dice will skip the roll dialog window by default. If the shift key is held while clicking, the window will be shown instead.",
                 "Name": "Use Quick roll by default?"
             },
             "UseStarfinderAOETemplates": {

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -186,7 +186,7 @@ export class DiceSFRPG {
             buttons: buttons,
             defaultButton: "normal",
             title: title,
-            skipUI: (event?.shiftKey || game.settings.get('sfrpg', 'useQuickRollAsDefault') || dialogOptions?.skipUI) && !rollContext.hasMultipleSelectors(),
+            skipUI: ((game.settings.get('sfrpg', 'useQuickRollAsDefault')) ? !event?.shiftKey : event?.shiftKey || dialogOptions?.skipUI) && !rollContext.hasMultipleSelectors(),
             mainDie: "1d20",
             dialogOptions: dialogOptions,
             useRawStrings: false
@@ -359,7 +359,7 @@ export class DiceSFRPG {
             buttons: buttons,
             defaultButton: "normal",
             title: title,
-            skipUI: (event?.shiftKey || game.settings.get('sfrpg', 'useQuickRollAsDefault') || dialogOptions?.skipUI) && !rollContext.hasMultipleSelectors(),
+            skipUI: ((game.settings.get('sfrpg', 'useQuickRollAsDefault')) ? !event?.shiftKey : event?.shiftKey || dialogOptions?.skipUI) && !rollContext.hasMultipleSelectors(),
             mainDie: mainDie ? "1" + mainDie : null,
             dialogOptions: dialogOptions,
             useRawStrings: useRawStrings
@@ -514,7 +514,7 @@ export class DiceSFRPG {
             buttons: buttons,
             defaultButton: "normal",
             title: title,
-            skipUI: (event?.shiftKey || game.settings.get('sfrpg', 'useQuickRollAsDefault') || dialogOptions?.skipUI) && !rollContext.hasMultipleSelectors(),
+            skipUI: ((game.settings.get('sfrpg', 'useQuickRollAsDefault')) ? !event?.shiftKey : event?.shiftKey || dialogOptions?.skipUI) && !rollContext.hasMultipleSelectors(),
             mainDie: "",
             dialogOptions: dialogOptions,
             parts,


### PR DESCRIPTION
Currently, when the skip dialog option is checked, shift-clicking a roll has no effect. It would be more intuitive if this setting instead acted as an inversion of the default behavior: showing the dialog on a shift-click. 

Closes #635 