### PR TITLE
Applying damage to a starship from a chat card obeys the Damage Rounding Advantage setting

### DIFF
--- a/src/module/actor/mixins/actor-damage.js
+++ b/src/module/actor/mixins/actor-damage.js
@@ -507,15 +507,15 @@ export const ActorDamageMixin = (superclass) => class extends superclass {
         let actorUpdate = {};
         const newData = duplicate(originalData);
 
-        const damageRoundingAdvantage = game.settings.get("sfrpg", "damageRoundingAdvantage");
-        const isRoundingDefender = (damageRoundingAdvantage === "defender");
-
         let remainingUndealtDamage = damage.amount;
         
-        if (isRoundingDefender) {
-            remainingUndealtDamage = Math.floor(remainingUndealtDamage);
-        } else {
-            remainingUndealtDamage = Math.ceil(remainingUndealtDamage);
+        if (remainingUndealtDamage % 1 !== 0) {
+            const damageRoundingAdvantage = game.settings.get("sfrpg", "damageRoundingAdvantage");
+            if (damageRoundingAdvantage === "defender") {
+                remainingUndealtDamage = Math.floor(remainingUndealtDamage);
+            } else {
+                remainingUndealtDamage = Math.ceil(remainingUndealtDamage);
+            }
         }
         
         const hasDeflectorShields = this.data.data.hasDeflectorShields;

--- a/src/module/actor/mixins/actor-damage.js
+++ b/src/module/actor/mixins/actor-damage.js
@@ -507,7 +507,17 @@ export const ActorDamageMixin = (superclass) => class extends superclass {
         let actorUpdate = {};
         const newData = duplicate(originalData);
 
+        const damageRoundingAdvantage = game.settings.get("sfrpg", "damageRoundingAdvantage");
+        const isRoundingDefender = (damageRoundingAdvantage === "defender");
+
         let remainingUndealtDamage = damage.amount;
+        
+        if (isRoundingDefender) {
+            remainingUndealtDamage = Math.floor(remainingUndealtDamage);
+        } else {
+            remainingUndealtDamage = Math.ceil(remainingUndealtDamage);
+        }
+        
         const hasDeflectorShields = this.data.data.hasDeflectorShields;
         const hasAblativeArmor = this.data.data.hasAblativeArmor;
         


### PR DESCRIPTION
Currently when applying 1/2 or 1.5x damage, you can end up dealing fractional damage, which is far from intended.