### PR TITLE
Drift Crisis equipment/gear

### DIFF
--- a/src/items/equipment/abyssal_plate_balor.json
+++ b/src/items/equipment/abyssal_plate_balor.json
@@ -1,0 +1,166 @@
+{
+  "_id": "j0O9fj1R1LU85tyB",
+  "name": "Abyssal plate, balor",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -4,
+      "dex": 4,
+      "eac": 26,
+      "kac": 28,
+      "speedAdjust": -5
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 105
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "4",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 4,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmNotes": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Normally crafted by demonic smiths, abyssal plate tends to be rare, but sets of this armor reverse-engineered from those taken from vanquished fiends are slowly gaining a presence in the galactic market. Abyssal plate sacrifices adaptability for speed, giving it less room for armor upgrades than its competitors. Demon-made sets are rumored to be forged with sinners’ souls, but that ingredient is something most mortal corporations don’t attempt to emulate.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 20,
+    "modifiers": [],
+    "price": 944000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/abyssal_plate_glabrezu.json
+++ b/src/items/equipment/abyssal_plate_glabrezu.json
@@ -1,0 +1,166 @@
+{
+  "_id": "cHVicJvMnbVUriNx",
+  "name": "Abyssal plate, glabrezu",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -4,
+      "dex": 2,
+      "eac": 17,
+      "kac": 19,
+      "speedAdjust": -5
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 48
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "3",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmNotes": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Normally crafted by demonic smiths, abyssal plate tends to be rare, but sets of this armor reverse-engineered from those taken from vanquished fiends are slowly gaining a presence in the galactic market. Abyssal plate sacrifices adaptability for speed, giving it less room for armor upgrades than its competitors. Demon-made sets are rumored to be forged with sinners’ souls, but that ingredient is something most mortal corporations don’t attempt to emulate.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 11,
+    "modifiers": [],
+    "price": 24000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/abyssal_plate_marilith.json
+++ b/src/items/equipment/abyssal_plate_marilith.json
@@ -1,0 +1,165 @@
+{
+  "_id": "H4sXDNcHr6ywDh61",
+  "name": "Abyssal plate, marilith",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -4,
+      "dex": 4,
+      "eac": 21,
+      "kac": 23,
+      "speedAdjust": -5
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 90
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "4",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 3,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Normally crafted by demonic smiths, abyssal plate tends to be rare, but sets of this armor reverse-engineered from those taken from vanquished fiends are slowly gaining a presence in the galactic market. Abyssal plate sacrifices adaptability for speed, giving it less room for armor upgrades than its competitors. Demon-made sets are rumored to be forged with sinners&rsquo; souls, but that ingredient is something most mortal corporations don&rsquo;t attempt to emulate.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 15,
+    "modifiers": [],
+    "price": 116500,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/abyssal_plate_vrock.json
+++ b/src/items/equipment/abyssal_plate_vrock.json
@@ -1,0 +1,165 @@
+{
+  "_id": "6QV3ELggnZvDpz0R",
+  "name": "Abyssal plate, vrock",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -3,
+      "dex": 2,
+      "eac": 14,
+      "kac": 16,
+      "speedAdjust": -5
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "3",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 1,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Normally crafted by demonic smiths, abyssal plate tends to be rare, but sets of this armor reverse-engineered from those taken from vanquished fiends are slowly gaining a presence in the galactic market. Abyssal plate sacrifices adaptability for speed, giving it less room for armor upgrades than its competitors. Demon-made sets are rumored to be forged with sinners&rsquo; souls, but that ingredient is something most mortal corporations don&rsquo;t attempt to emulate.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 8,
+    "modifiers": [],
+    "price": 11150,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/alluvion_theodolite.json
+++ b/src/items/equipment/alluvion_theodolite.json
@@ -1,0 +1,87 @@
+{
+  "_id": "pbaCUWdYlqWLeAe1",
+  "name": "Alluvion theodolite",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 8
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This clockwork precision instrument, often mounted on the bridge of a starship, allows you to glean the distance and direction of Alluvion, the itinerant city in the Drift. While you&rsquo;re in the Drift, the </span><span class=\"fontstyle2\">theodolite </span><span class=\"fontstyle0\">gives you a +4 insight bonus to astrogate to Alluvion (though you must still have received coordinates from some other source).</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 3,
+    "limitedWear": false,
+    "modifiers": [
+      {
+        "_id": "d1b1c5e3-7af8-4c4a-a33c-9f8550302830",
+        "name": "Alluvion theodolite",
+        "type": "insight",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "While you’re in the Drift, the theodolite gives you a +4 insight bonus to astrogate to Alluvion",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "pil"
+      }
+    ],
+    "price": 1750,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/antimagic_grenade_i_(hybrid).json
+++ b/src/items/equipment/antimagic_grenade_i_(hybrid).json
@@ -1,0 +1,249 @@
+{
+  "_id": "qPdHTVcuu9HE0vpc",
+  "name": "Antimagic grenade I (Hybrid)",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 20
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 90
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 15,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">An </span><span class=\"fontstyle2\">antimagic grenade </span><span class=\"fontstyle0\">creates a temporary field that inhibits magic in its radius. Upon detonation, everything in the grenade&rsquo;s radius is affected by an area dispel as @Compendium[sfrpg.spells.1FfFraWlxCu1L4rL]{Dispel Magic, Greater}</span><span class=\"fontstyle0\">, using the grenade&rsquo;s item level as the caster level. Second, each creature in the explosion radius must make a Will save each time they attempt to cast a spell or use a spell-like ability for a number of rounds equal to the grenade&rsquo;s model number, or lose the spell or spell-like ability. A creature, object, or area can be affected by only one </span><span class=\"fontstyle2\">antimagic grenade </span><span class=\"fontstyle0\">every 24 hours.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 15,
+    "modifiers": [],
+    "price": 27500,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "will",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": "Staggered"
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/smoke-grenade.webp"
+}

--- a/src/items/equipment/antimagic_grenade_ii_(hybrid).json
+++ b/src/items/equipment/antimagic_grenade_ii_(hybrid).json
@@ -1,0 +1,249 @@
+{
+  "_id": "7eUe8KTxgpaw4Mbw",
+  "name": "Antimagic grenade II (Hybrid)",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 20
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 90
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 19,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">An </span><span class=\"fontstyle2\">antimagic grenade </span><span class=\"fontstyle0\">creates a temporary field that inhibits magic in its radius. Upon detonation, everything in the grenade&rsquo;s radius is affected by an area dispel as @Compendium[sfrpg.spells.1FfFraWlxCu1L4rL]{Dispel Magic, Greater}</span><span class=\"fontstyle0\">, using the grenade&rsquo;s item level as the caster level. Second, each creature in the explosion radius must make a Will save each time they attempt to cast a spell or use a spell-like ability for a number of rounds equal to the grenade&rsquo;s model number, or lose the spell or spell-like ability. A creature, object, or area can be affected by only one </span><span class=\"fontstyle2\">antimagic grenade </span><span class=\"fontstyle0\">every 24 hours.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 19,
+    "modifiers": [],
+    "price": 172000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "will",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": "Staggered"
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/smoke-grenade.webp"
+}

--- a/src/items/equipment/autoencoded_veil_i.json
+++ b/src/items/equipment/autoencoded_veil_i.json
@@ -1,0 +1,181 @@
+{
+  "_id": "TU0Jp86ICpXwKzOU",
+  "name": "Autoencoded veil I",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 4,
+      "eac": 4,
+      "kac": 4,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 27
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 1,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This sleek armor integrates extensive wiring and recycled material directly into the fabric, reinforcing key areas with advanced plating. You can spend 10 minutes programming your armor with either an alternate appearance or a stealth routine. Your armor then disguises your features to technological sensors (including cameras and creatures with the technological subtype). For an alternate appearance, this functions as if you used Disguise to change your appearance, with a Perception check DC to pierce the disguise equal to 15 + 1-1/2 &times; the armor&rsquo;s item level. For a stealth routine, the armor disrupts how technological scanners perceive you, granting you a +2 circumstance bonus to Stealth checks against technological sensors and 10% miss chance against attacks made by technological sources. The armor&rsquo;s sensor-disrupting effect is imperceptible to non-technological sources, which can perceive you normally</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 4,
+    "modifiers": [
+      {
+        "_id": "7269a102-25b6-4263-ae51-ed878f249410",
+        "name": "Autoencoded veil",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 2100,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "size": "",
+    "source": "DC pg. 85",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/autoencoded_veil_ii.json
+++ b/src/items/equipment/autoencoded_veil_ii.json
@@ -1,0 +1,181 @@
+{
+  "_id": "D1WNh969yyFaF7ht",
+  "name": "Autoencoded veil II",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 5,
+      "eac": 9,
+      "kac": 10,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This sleek armor integrates extensive wiring and recycled material directly into the fabric, reinforcing key areas with advanced plating. You can spend 10 minutes programming your armor with either an alternate appearance or a stealth routine. Your armor then disguises your features to technological sensors (including cameras and creatures with the technological subtype). For an alternate appearance, this functions as if you used Disguise to change your appearance, with a Perception check DC to pierce the disguise equal to 15 + 1-1/2 &times; the armor&rsquo;s item level. For a stealth routine, the armor disrupts how technological scanners perceive you, granting you a +2 circumstance bonus to Stealth checks against technological sensors and 10% miss chance against attacks made by technological sources. The armor&rsquo;s sensor-disrupting effect is imperceptible to non-technological sources, which can perceive you normally</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 8,
+    "modifiers": [
+      {
+        "_id": "7269a102-25b6-4263-ae51-ed878f249410",
+        "name": "Autoencoded veil",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 9500,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "size": "",
+    "source": "DC pg. 85",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/autoencoded_veil_iii.json
+++ b/src/items/equipment/autoencoded_veil_iii.json
@@ -1,0 +1,182 @@
+{
+  "_id": "8RuLdqU7jnR2yCMp",
+  "name": "Autoencoded veil III",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 5,
+      "eac": 13,
+      "kac": 15,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 51
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This sleek armor integrates extensive wiring and recycled material directly into the fabric, reinforcing key areas with advanced plating. You can spend 10 minutes programming your armor with either an alternate appearance or a stealth routine. Your armor then disguises your features to technological sensors (including cameras and creatures with the technological subtype). For an alternate appearance, this functions as if you used Disguise to change your appearance, with a Perception check DC to pierce the disguise equal to 15 + 1-1/2 &times; the armor&rsquo;s item level. For a stealth routine, the armor disrupts how technological scanners perceive you, granting you a +2 circumstance bonus to Stealth checks against technological sensors and 10% miss chance against attacks made by technological sources. The armor&rsquo;s sensor-disrupting effect is imperceptible to non-technological sources, which can perceive you normally</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 12,
+    "modifiers": [
+      {
+        "_id": "7269a102-25b6-4263-ae51-ed878f249410",
+        "name": "Autoencoded veil",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 36500,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "size": "",
+    "source": "DC pg. 85",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/autoencoded_veil_iv.json
+++ b/src/items/equipment/autoencoded_veil_iv.json
@@ -1,0 +1,181 @@
+{
+  "_id": "nBAS1p22dDlWsWKi",
+  "name": "Autoencoded veil IV",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 6,
+      "eac": 19,
+      "kac": 20,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 93
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 3,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This sleek armor integrates extensive wiring and recycled material directly into the fabric, reinforcing key areas with advanced plating. You can spend 10 minutes programming your armor with either an alternate appearance or a stealth routine. Your armor then disguises your features to technological sensors (including cameras and creatures with the technological subtype). For an alternate appearance, this functions as if you used Disguise to change your appearance, with a Perception check DC to pierce the disguise equal to 15 + 1-1/2 &times; the armor&rsquo;s item level. For a stealth routine, the armor disrupts how technological scanners perceive you, granting you a +2 circumstance bonus to Stealth checks against technological sensors and 10% miss chance against attacks made by technological sources. The armor&rsquo;s sensor-disrupting effect is imperceptible to non-technological sources, which can perceive you normally</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 16,
+    "modifiers": [
+      {
+        "_id": "7269a102-25b6-4263-ae51-ed878f249410",
+        "name": "Autoencoded veil",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 175000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "size": "",
+    "source": "DC pg. 85",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/autoencoded_veil_v.json
+++ b/src/items/equipment/autoencoded_veil_v.json
@@ -1,0 +1,181 @@
+{
+  "_id": "nDe3RWfXRaIyX4S8",
+  "name": "Autoencoded veil V",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 7,
+      "eac": 22,
+      "kac": 22,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 105
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 4,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This sleek armor integrates extensive wiring and recycled material directly into the fabric, reinforcing key areas with advanced plating. You can spend 10 minutes programming your armor with either an alternate appearance or a stealth routine. Your armor then disguises your features to technological sensors (including cameras and creatures with the technological subtype). For an alternate appearance, this functions as if you used Disguise to change your appearance, with a Perception check DC to pierce the disguise equal to 15 + 1-1/2 &times; the armor&rsquo;s item level. For a stealth routine, the armor disrupts how technological scanners perceive you, granting you a +2 circumstance bonus to Stealth checks against technological sensors and 10% miss chance against attacks made by technological sources. The armor&rsquo;s sensor-disrupting effect is imperceptible to non-technological sources, which can perceive you normally</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 20,
+    "modifiers": [
+      {
+        "_id": "7269a102-25b6-4263-ae51-ed878f249410",
+        "name": "Autoencoded veil",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 850000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "size": "",
+    "source": "DC pg. 85",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/banishing_blade_mk_1.json
+++ b/src/items/equipment/banishing_blade_mk_1.json
@@ -1,0 +1,252 @@
+{
+  "_id": "d5fsrdKiBbJmC0X3",
+  "name": "Banishing blade, Mk 1",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": 0
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 8,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d8 + @abilities.str.mod",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": true,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Banishing blades&nbsp;</span><span class=\"fontstyle2\">are magic weapons capable of forcing extraplanar foes back to their native plane. These weapons were once used primarily by the Church of Iomedae in its crusades against fiendish incursions, but the Drift Crisis brought growing concerns that other extraplanar creatures might threaten the Material Plane, and production of these weapons accelerated. All&nbsp;</span><span class=\"fontstyle0\">banishing blades&nbsp;</span><span class=\"fontstyle2\">function as if they had the @Compendium[sfrpg.equipment.5KsmBkidShbIetHD]{Holy}</span><span class=\"fontstyle0\">&nbsp;</span><span class=\"fontstyle2\">fusion in addition to the rest of their abilities. This counts against how many total fusions a&nbsp;</span><span class=\"fontstyle0\">banishing blade&nbsp;</span><span class=\"fontstyle2\">can have.</span></p>\n<p><span class=\"fontstyle2\">If you score a critical hit against a creature with the extraplanar subtype, that creature must succeed at Will save (DC = 10 + item level + your key ability score modifier) or be sent back to its home plane, as the spell&nbsp;</span><span class=\"fontstyle0\">dismissal</span><span class=\"fontstyle2\">, with the following exceptions: if the creature also has the evil subtype, the&nbsp;</span><span class=\"fontstyle0\">banishing blade&nbsp;</span><span class=\"fontstyle2\">counts as an object the subject opposes, granting a +2 to the save DC and a +1 on caster-level checks to overcome the subject&rsquo;s spell resistance, if any. If you must make a caster-level check to overcome a target&rsquo;s spell resistance to use this effect, use the&nbsp;</span><span class=\"fontstyle0\">banishing blade</span><span class=\"fontstyle2\">&rsquo;s item level as your caster level. For&nbsp;</span><span class=\"fontstyle0\">mk 1&nbsp;</span><span class=\"fontstyle2\">and&nbsp;</span><span class=\"fontstyle0\">mk 2 banishing blades</span><span class=\"fontstyle2\">, the banished creature automatically returns in the same spot from where it was banished after 1 minute has elapsed.</span></p>\n<p><span class=\"fontstyle2\"><span class=\"fontstyle0\"><strong>Mk 1 (Level 8):</strong> </span><span class=\"fontstyle2\">Functions as a @Compendium[sfrpg.equipment.9N81Lk3nY5AvVhyN]{Longsword, sintered}.</span></span></p>\n<p><br /><em>Apply Holy fusion to weapon after placing in Inventory.</em></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 8,
+    "modifiers": [],
+    "price": 10500,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 54",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "advancedM"
+  },
+  "img": "icons/weapons/swords/sword-gold-holy.webp"
+}

--- a/src/items/equipment/banishing_blade_mk_2.json
+++ b/src/items/equipment/banishing_blade_mk_2.json
@@ -1,0 +1,252 @@
+{
+  "_id": "MvlUiZ2ZYpKKs1Hq",
+  "name": "Banishing blade, Mk 2",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": 0
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 51
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 12,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d8 + @abilities.str.mod",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": true,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Banishing blades&nbsp;</span><span class=\"fontstyle2\">are magic weapons capable of forcing extraplanar foes back to their native plane. These weapons were once used primarily by the Church of Iomedae in its crusades against fiendish incursions, but the Drift Crisis brought growing concerns that other extraplanar creatures might threaten the Material Plane, and production of these weapons accelerated. All&nbsp;</span><span class=\"fontstyle0\">banishing blades&nbsp;</span><span class=\"fontstyle2\">function as if they had the @Compendium[sfrpg.equipment.5KsmBkidShbIetHD]{Holy}</span><span class=\"fontstyle0\">&nbsp;</span><span class=\"fontstyle2\">fusion in addition to the rest of their abilities. This counts against how many total fusions a&nbsp;</span><span class=\"fontstyle0\">banishing blade&nbsp;</span><span class=\"fontstyle2\">can have.</span></p>\n<p><span class=\"fontstyle2\">If you score a critical hit against a creature with the extraplanar subtype, that creature must succeed at Will save (DC = 10 + item level + your key ability score modifier) or be sent back to its home plane, as the spell&nbsp;</span><span class=\"fontstyle0\">dismissal</span><span class=\"fontstyle2\">, with the following exceptions: if the creature also has the evil subtype, the&nbsp;</span><span class=\"fontstyle0\">banishing blade&nbsp;</span><span class=\"fontstyle2\">counts as an object the subject opposes, granting a +2 to the save DC and a +1 on caster-level checks to overcome the subject&rsquo;s spell resistance, if any. If you must make a caster-level check to overcome a target&rsquo;s spell resistance to use this effect, use the&nbsp;</span><span class=\"fontstyle0\">banishing blade</span><span class=\"fontstyle2\">&rsquo;s item level as your caster level. For&nbsp;</span><span class=\"fontstyle0\">mk 1&nbsp;</span><span class=\"fontstyle2\">and&nbsp;</span><span class=\"fontstyle0\">mk 2 banishing blades</span><span class=\"fontstyle2\">, the banished creature automatically returns in the same spot from where it was banished after 1 minute has elapsed.</span></p>\n<p><span class=\"fontstyle0\"><strong>Mk 2 (Level 12):</strong> </span><span class=\"fontstyle2\">Functions as an @Compendium[sfrpg.equipment.nEAqLcFGXCpe92fY]{Longsword, ultrathin}.</span> </p>\n<p><br /><em>Apply Holy fusion to weapon after placing in Inventory.</em></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 12,
+    "modifiers": [],
+    "price": 39000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 54",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "advancedM"
+  },
+  "img": "icons/weapons/swords/sword-gold-holy.webp"
+}

--- a/src/items/equipment/banishing_blade_mk_3.json
+++ b/src/items/equipment/banishing_blade_mk_3.json
@@ -1,0 +1,252 @@
+{
+  "_id": "EvP68diFpQzbb9KC",
+  "name": "Banishing blade, Mk 3",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": 0
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 96
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 17,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "10d8 + @abilities.str.mod",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": true,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Banishing blades&nbsp;</span><span class=\"fontstyle2\">are magic weapons capable of forcing extraplanar foes back to their native plane. These weapons were once used primarily by the Church of Iomedae in its crusades against fiendish incursions, but the Drift Crisis brought growing concerns that other extraplanar creatures might threaten the Material Plane, and production of these weapons accelerated. All&nbsp;</span><span class=\"fontstyle0\">banishing blades&nbsp;</span><span class=\"fontstyle2\">function as if they had the @Compendium[sfrpg.equipment.5KsmBkidShbIetHD]{Holy}</span><span class=\"fontstyle0\">&nbsp;</span><span class=\"fontstyle2\">fusion in addition to the rest of their abilities. This counts against how many total fusions a&nbsp;</span><span class=\"fontstyle0\">banishing blade&nbsp;</span><span class=\"fontstyle2\">can have.</span></p>\n<p><span class=\"fontstyle2\">If you score a critical hit against a creature with the extraplanar subtype, that creature must succeed at Will save (DC = 10 + item level + your key ability score modifier) or be sent back to its home plane, as the spell&nbsp;</span><span class=\"fontstyle0\">dismissal</span><span class=\"fontstyle2\">, with the following exceptions: if the creature also has the evil subtype, the&nbsp;</span><span class=\"fontstyle0\">banishing blade&nbsp;</span><span class=\"fontstyle2\">counts as an object the subject opposes, granting a +2 to the save DC and a +1 on caster-level checks to overcome the subject&rsquo;s spell resistance, if any. If you must make a caster-level check to overcome a target&rsquo;s spell resistance to use this effect, use the&nbsp;</span><span class=\"fontstyle0\">banishing blade</span><span class=\"fontstyle2\">&rsquo;s item level as your caster level. For&nbsp;</span><span class=\"fontstyle0\">mk 1&nbsp;</span><span class=\"fontstyle2\">and&nbsp;</span><span class=\"fontstyle0\">mk 2 banishing blades</span><span class=\"fontstyle2\">, the banished creature automatically returns in the same spot from where it was banished after 1 minute has elapsed.</span></p>\n<p><span class=\"fontstyle0\"><strong>Mk 3 (Level 17):</strong> </span><span class=\"fontstyle2\">Functions as a @Compendium[sfrpg.equipment.ynDdoBQV0HrW31AK]{Longsword, molecular rift}.</span></p>\n<p><br /><em>Apply Holy fusion to weapon after placing in Inventory.</em></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 17,
+    "modifiers": [],
+    "price": 289000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 54",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "advancedM"
+  },
+  "img": "icons/weapons/swords/sword-gold-holy.webp"
+}

--- a/src/items/equipment/banishing_blade_mk_4.json
+++ b/src/items/equipment/banishing_blade_mk_4.json
@@ -1,0 +1,252 @@
+{
+  "_id": "GKVHe4DPCRWMOyQD",
+  "name": "Banishing blade, Mk 4",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": 0
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 105
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 20,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "14d8 + @abilities.str.mod",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": true,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Banishing blades&nbsp;</span><span class=\"fontstyle2\">are magic weapons capable of forcing extraplanar foes back to their native plane. These weapons were once used primarily by the Church of Iomedae in its crusades against fiendish incursions, but the Drift Crisis brought growing concerns that other extraplanar creatures might threaten the Material Plane, and production of these weapons accelerated. All&nbsp;</span><span class=\"fontstyle0\">banishing blades&nbsp;</span><span class=\"fontstyle2\">function as if they had the @Compendium[sfrpg.equipment.5KsmBkidShbIetHD]{Holy}</span><span class=\"fontstyle0\">&nbsp;</span><span class=\"fontstyle2\">fusion in addition to the rest of their abilities. This counts against how many total fusions a&nbsp;</span><span class=\"fontstyle0\">banishing blade&nbsp;</span><span class=\"fontstyle2\">can have.</span></p>\n<p><span class=\"fontstyle2\">If you score a critical hit against a creature with the extraplanar subtype, that creature must succeed at Will save (DC = 10 + item level + your key ability score modifier) or be sent back to its home plane, as the spell&nbsp;</span><span class=\"fontstyle0\">dismissal</span><span class=\"fontstyle2\">, with the following exceptions: if the creature also has the evil subtype, the&nbsp;</span><span class=\"fontstyle0\">banishing blade&nbsp;</span><span class=\"fontstyle2\">counts as an object the subject opposes, granting a +2 to the save DC and a +1 on caster-level checks to overcome the subject&rsquo;s spell resistance, if any. If you must make a caster-level check to overcome a target&rsquo;s spell resistance to use this effect, use the&nbsp;</span><span class=\"fontstyle0\">banishing blade</span><span class=\"fontstyle2\">&rsquo;s item level as your caster level. For&nbsp;</span><span class=\"fontstyle0\">mk 1&nbsp;</span><span class=\"fontstyle2\">and&nbsp;</span><span class=\"fontstyle0\">mk 2 banishing blades</span><span class=\"fontstyle2\">, the banished creature automatically returns in the same spot from where it was banished after 1 minute has elapsed.</span></p>\n<p><strong><span class=\"fontstyle0\">Mk 4 (Level 20): </span></strong><span class=\"fontstyle2\">Functions as a @Compendium[sfrpg.equipment.umj1k1Ll8PLtcmyE]{Longsword, dimensional slice}.</span></p>\n<p><em>Apply Holy fusion to weapon after placing in Inventory.</em></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 20,
+    "modifiers": [],
+    "price": 967000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 54",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "advancedM"
+  },
+  "img": "icons/weapons/swords/sword-gold-holy.webp"
+}

--- a/src/items/equipment/besmaran_rose.json
+++ b/src/items/equipment/besmaran_rose.json
@@ -1,0 +1,71 @@
+{
+  "_id": "yyYnEVwCRYCkpBxk",
+  "name": "Besmaran Rose",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 50
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 1,
+      "value": 1
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">Besmaran Rose </span><span class=\"fontstyle0\">is an archaic, ornate compass with stylized flower petals around its circumference and a skeletal finger in place of a needle. Found in the possession of presumed Pirate Council members emerging from the Gap, these compasses have become informal badges for some councilors, with a pirate lord&rsquo;s </span><span class=\"fontstyle2\">Besmaran Rose </span><span class=\"fontstyle0\">being passed to the next most senior </span><span class=\"fontstyle0\">councillor upon the former&rsquo;s death. Among the Free Captains, losing a </span><span class=\"fontstyle2\">Besmaran Rose </span><span class=\"fontstyle0\">is considered a terrible omen, signaling the owner&rsquo;s imminent demise. Besmara&rsquo;s faith periodically creates more of these items, yet the devices remain rare.</span></p>\n<p><span class=\"fontstyle0\">Once per week while holding a </span><span class=\"fontstyle2\">Besmaran Rose</span><span class=\"fontstyle0\">, you can spend a full action to name an object, person, or place anywhere in the galaxy, prick your skin, and drip a drop of blood (or similar substance) onto the compass&rsquo;s needle. The device quickly absorbs the blood, turns a reddish hue, and causes the skeletal finger to whirl indecisively for a moment. The compass attempts a special check, rolling 1d20+15 with a DC based on the named subject&rsquo;s obscurity. The compass automatically succeeds in detecting a common subject, such as &ldquo;potable water&rdquo; or &ldquo;a station that can repair our starship.&rdquo; Rarer or more specific subjects are DC 20, such as &ldquo;undersea treasure&rdquo; or &ldquo;the closest starport operated by the Veskarium.&rdquo; Unique or carefully hidden subjects are typically DC 25 or higher, depending on their rarity, such as &ldquo;Rasheen&rsquo;s sunken treasure&rdquo; or a specific and covert smuggler. Some subjects, like requesting secrets about the Gap, automatically fail.</span></p>\n<p><span class=\"fontstyle0\">If the compass fails, it provides no benefit. If the compass succeeds, it imparts a helpful vision about the subject&rsquo;s location, such as a nearby landmark. Until the compass is activated again, it can rest atop a starship&rsquo;s or vehicle&rsquo;s controls, granting the pilot a +10 bonus to astrogate and navigate to the location. However, the </span><span class=\"fontstyle2\">Besmaran Rose </span><span class=\"fontstyle0\">only brings the user close to the objective, and additional local exploration and investigation are often necessary to uncover hidden destinations.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 15,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 103300,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 133",
+    "usage": {
+      "per": "",
+      "value": 1
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/burrowing_arms_mk_1.json
+++ b/src/items/equipment/burrowing_arms_mk_1.json
@@ -1,0 +1,88 @@
+{
+  "_id": "BtOipMyuMtaY6nPx",
+  "name": "Burrowing arms, Mk 1",
+  "type": "upgrade",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "allowedArmorType": "any",
+    "ammunitionType": "",
+    "armorType": "power",
+    "attributes": {
+      "ac": {
+        "value": "5"
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "21"
+      },
+      "hp": {
+        "max": "39",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This armor upgrade became popular for adventurers who needed to traverse the Plane of Earth, which can frequently require excavation. It consists of modifications to the arms that allow you to quickly move dirt and other loose material, granting a burrow speed. Unless otherwise stated, burrowing arms can&rsquo;t be used to burrow through solid rock or metal. This upgrade can be installed only in heavy or powered armor.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 7,
+    "modifiers": [
+      {
+        "_id": "4c2a9b62-b477-4217-8716-fc390f7cc0b5",
+        "name": "Burrowing arms, Mk 1",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "specific-speed",
+        "enabled": true,
+        "max": 5,
+        "modifier": "5",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "burrowing"
+      }
+    ],
+    "price": 7350,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "slots": 1,
+    "source": "GM pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/burrowing_arms_mk_2.json
+++ b/src/items/equipment/burrowing_arms_mk_2.json
@@ -1,0 +1,88 @@
+{
+  "_id": "dVK5EWtmnXscV03Q",
+  "name": "Burrowing arms, Mk 2",
+  "type": "upgrade",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "allowedArmorType": "any",
+    "ammunitionType": "",
+    "armorType": "power",
+    "attributes": {
+      "ac": {
+        "value": "5"
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "21"
+      },
+      "hp": {
+        "max": "39",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This armor upgrade became popular for adventurers who needed to traverse the Plane of Earth, which can frequently require excavation. It consists of modifications to the arms that allow you to quickly move dirt and other loose material, granting a burrow speed. Unless otherwise stated, burrowing arms can&rsquo;t be used to burrow through solid rock or metal. This upgrade can be installed only in heavy or powered armor.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 11,
+    "modifiers": [
+      {
+        "_id": "4c2a9b62-b477-4217-8716-fc390f7cc0b5",
+        "name": "Burrowing arms, Mk 2",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "specific-speed",
+        "enabled": true,
+        "max": 10,
+        "modifier": "10",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "burrowing"
+      }
+    ],
+    "price": 25000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "slots": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/burrowing_arms_mk_3.json
+++ b/src/items/equipment/burrowing_arms_mk_3.json
@@ -1,0 +1,88 @@
+{
+  "_id": "7pDDq3qWmPeKXDoB",
+  "name": "Burrowing arms, Mk 3",
+  "type": "upgrade",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "allowedArmorType": "any",
+    "ammunitionType": "",
+    "armorType": "power",
+    "attributes": {
+      "ac": {
+        "value": "5"
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "21"
+      },
+      "hp": {
+        "max": "39",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This armor upgrade became popular for adventurers who needed to traverse the Plane of Earth, which can frequently require excavation. It consists of modifications to the arms that allow you to quickly move dirt and other loose material, granting a burrow speed. Unless otherwise stated, burrowing arms can&rsquo;t be used to burrow through solid rock or metal. This upgrade can be installed only in heavy or powered armor.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 13,
+    "modifiers": [
+      {
+        "_id": "4c2a9b62-b477-4217-8716-fc390f7cc0b5",
+        "name": "Burrowing arms, Mk 3",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "specific-speed",
+        "enabled": true,
+        "max": 15,
+        "modifier": "15",
+        "modifierType": "constant",
+        "notes": "you can burrow through solid rock at a speed of 5\nfeet.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "burrowing"
+      }
+    ],
+    "price": 51500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "slots": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/cartographer_boots.json
+++ b/src/items/equipment/cartographer_boots.json
@@ -1,0 +1,101 @@
+{
+  "_id": "Ey0L8t5YEDJrhu8A",
+  "name": "Cartographer boots",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "charge",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 9
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 40,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">These practical boots have integrated sensors that, when activated, track your footsteps and use that data to create a crude, three-dimensional map of where you move while using your land speed. This data is automatically uploaded to a designated comm unit within 30 feet. Periodically reviewing this map provides you a +1 circumstance bonus to checks to find hidden doors, passages, and other concealed architecture in the traversed area, as well as a +2 circumstance bonus to Survival checks to avoid getting lost.</span></p>\n<p><span class=\"fontstyle0\">Variants of these boots exist for other movement types, such as wing-mounted sensors for flight or a lightweight tail harness for swim speeds.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 4,
+    "modifiers": [
+      {
+        "_id": "d58720a3-386c-48a0-8630-7bd3a78d695b",
+        "name": "Cartographer boots",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 1,
+        "modifier": "1",
+        "modifierType": "formula",
+        "notes": "+1 circumstance bonus to checks to find hidden doors, passages, and other concealed architecture in the traversed area.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "per"
+      },
+      {
+        "_id": "dfe4bd32-5884-4a81-926e-26756d6410aa",
+        "name": "Cartographer boots",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "Grants a +2 circumstance bonus to Survival checks to avoid getting lost.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "sur"
+      }
+    ],
+    "price": 2100,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 79",
+    "usage": {
+      "per": "hour",
+      "value": 4
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/clothing_couture.json
+++ b/src/items/equipment/clothing_couture.json
@@ -1,0 +1,115 @@
+{
+  "_id": "N5pTnbWiGspAiE13",
+  "name": "Clothing, couture",
+  "type": "goods",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 13
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Couture clothing is typically one-of-a-kind clothing designed and crafted for a single specific client. Couture style is often ambitious and avant-garde, designed to make the wearer stand out. While wearing couture clothing, you gain a +2 bonus on Bluff, Diplomacy, and Intimidate checks when interacting </span><span class=\"fontstyle0\">with individuals who recognize the value of the garments, as determined by the GM. You also take a &ndash;4 penalty on Stealth checks to blend into a crowd while wearing couture clothing unless the crowd is also wearing similar garb. The listed price is for the cheapest couture clothing. Depending on the talent and reputation of the designer and the clothing materials, the price could be in the tens or even hundreds of thousands of credits.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 8,
+    "modifiers": [
+      {
+        "_id": "64b25a94-e835-4c51-91e7-9f12200486de",
+        "name": "Clothing, couture",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "While wearing couture clothing, you gain a +2 bonus on Bluff, Diplomacy, and Intimidate checks when interacting with individuals who recognize the value of the garments, as determined by the GM.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "blu"
+      },
+      {
+        "_id": "4d58f226-a38d-437b-bc1a-9a0e732c74b6",
+        "name": "Clothing, couture",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "While wearing couture clothing, you gain a +2 bonus on Bluff, Diplomacy, and Intimidate checks when interacting with individuals who recognize the value of the garments, as determined by the GM.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "dip"
+      },
+      {
+        "_id": "80d3e2f2-0e93-4ee8-a87a-5b8cc9037f62",
+        "name": "Clothing, couture",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "While wearing couture clothing, you gain a +2 bonus on Bluff, Diplomacy, and Intimidate checks when interacting with individuals who recognize the value of the garments, as determined by the GM.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "int"
+      },
+      {
+        "_id": "a2e1ea6b-7026-403a-9a91-947027e0cc2e",
+        "name": "Clothing, couture",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": -4,
+        "modifier": "-4",
+        "modifierType": "formula",
+        "notes": "You take a –4 penalty on Stealth checks to blend into a crowd while wearing couture clothing unless the crowd is also wearing similar garb.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 5000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 129"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/clothing_designer.json
+++ b/src/items/equipment/clothing_designer.json
@@ -1,0 +1,54 @@
+{
+  "_id": "VPc6Gzf3yBGOGV6M",
+  "name": "Clothing, designer",
+  "type": "goods",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 9
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Designer clothing is associated with a specific designer and tends to be of a higher quality than generic clothing. You can get designer versions of other outfits. This listed price modification is for the cheapest designer clothing, though depending on the brand, the price can rocket into thousands of credits. Wearing a designer version of an outfit confers the same benefit of the base outfit, except any circumstance bonuses to skill checks given by the base outfit are increased by 1 due to the increased quality. Designer clothing has the same bulk as the base outfit.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>This item reflects a change in another clothing item. Adjust price of base outfit to include cost of this item. As well as any changes this imparts to the base outfit.</em></span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 4,
+    "modifiers": [],
+    "price": 600,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 129"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/consciousness_transfer_unit.json
+++ b/src/items/equipment/consciousness_transfer_unit.json
@@ -1,0 +1,71 @@
+{
+  "_id": "HuKQMbF1MigpjM3k",
+  "name": "Consciousness transfer unit",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 19
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "20",
+    "capacity": {
+      "max": 1,
+      "value": 1
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This metal-and-glass disk is 8 feet in diameter and has a series of sensors and electrodes mounted along one edge. In a process that takes 1 minute, a creature lying on the disk can attach electrodes to their head (or equivalent region) and transfer their mind into a computer or construct adjacent to the consciousness transfer unit, functioning as @Compendium[sfrpg.spells.dIjaNl0eUXdoFpnN]{Transfer Consciousness}</span><span class=\"fontstyle0\" style=\"font-size: 5pt;\">COM </span><span class=\"fontstyle0\">(CL 14th). If the creature whose consciousness is transferred is unwilling, they can negate this effect with a successful DC 22 Will save. Once a creature has been affected by the device, whether the effect succeeded or not, they&rsquo;re immune to that consciousness transfer unit&rsquo;s effects for 24 hours.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 14,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 89700,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 133",
+    "usage": {
+      "per": "",
+      "value": 1
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/cosmetics.json
+++ b/src/items/equipment/cosmetics.json
@@ -1,0 +1,70 @@
+{
+  "_id": "2EBM4caRLBOrXe2B",
+  "name": "Cosmetics",
+  "type": "goods",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Cosmetics are usually liquids or powders used for covering blemishes or subtly altering one&rsquo;s facial features. They can be purchased in countless brands, colors, and styles. Using cosmetics to disguise yourself gives you a +1 circumstance bonus on Disguise checks as long as you are not attempting to disguise yourself as a different species.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 1,
+    "modifiers": [
+      {
+        "_id": "a2e1ea6b-7026-403a-9a91-947027e0cc2e",
+        "name": "Cosmetics",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 1,
+        "modifier": "1",
+        "modifierType": "formula",
+        "notes": "Using cosmetics to disguise yourself gives you a +1 circumstance bonus on Disguise checks as long as you are not attempting to disguise yourself as a different species.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "dis"
+      }
+    ],
+    "price": 20,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 129"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/drift_glass_goggles.json
+++ b/src/items/equipment/drift_glass_goggles.json
@@ -1,0 +1,112 @@
+{
+  "_id": "FvaiLJ8Exl0mpbqr",
+  "name": "Drift glass goggles",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "charge",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 13
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 20,
+      "value": 20
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Drift glass is a pinkish-brown crystalline substance harvested from areas where Drift architects have worked. They crumble to dust with any attempt to shape them, so they&rsquo;re awkwardly mounted whole in bulky goggles. While wearing Drift glass goggles, you have a &ndash;4 penalty to any vision-based skill or attack roll, but can see as if under the effects of a @Compendium[sfrpg.spells.5aW793TGgd3Kd4Fe]{See Invisibility}</span><span class=\"fontstyle2\">&nbsp;</span><span class=\"fontstyle0\">spell. They also allow you to determine whether a creature normally visible to you is incorporeal.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 8,
+    "modifiers": [
+      {
+        "_id": "62b76aa5-0478-4b49-944a-0ba540f7aff4",
+        "name": "Drift glass goggles",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "all-skills",
+        "enabled": false,
+        "max": -4,
+        "modifier": "-4",
+        "modifierType": "formula",
+        "notes": "While wearing Drift glass goggles, you have a –4 penalty to any vision-based skill or attack roll, but can see as if under the effects of a see invisibility spell. They also allow you to determine whether a creature normally visible to you is incorporeal.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "pro"
+      },
+      {
+        "_id": "496773b3-6964-47a4-908a-a91a4e9996ff",
+        "name": "Drift glass goggles",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "all-attacks",
+        "enabled": false,
+        "max": -4,
+        "modifier": "-4",
+        "modifierType": "formula",
+        "notes": "While wearing Drift glass goggles, you have a –4 penalty to any vision-based skill or attack roll, but can see as if under the effects of a see invisibility spell. They also allow you to determine whether a creature normally visible to you is incorporeal.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "acr"
+      }
+    ],
+    "price": 9100,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "minute",
+      "value": 1
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/drift_harness.json
+++ b/src/items/equipment/drift_harness.json
@@ -1,0 +1,101 @@
+{
+  "_id": "PGPl6EbK1aqfAfYl",
+  "name": "Drift harness",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "charge",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 19
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 100,
+      "value": 1
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Extreme miniaturization of Drift engine technology has resulted in this backpack with an extensive web of flexible plastic field emitters. Multiple tape-like extensions wrap along every limb, even fingers, antennae, tails, or similar appendages. Due to the complexity, a Drift harness takes 1 minute to put on. You can&rsquo;t wear a Drift harness while wearing any armor or any other item that prevents wearing armor.</span></p>\n<p><span class=\"fontstyle0\">As a full action, you can activate the Drift harness, permanently consuming a fully charged ultra-capacity battery. You enter the Drift until the beginning of your next turn, at which point you reappear in the same location. If that space is occupied when you return, you appear in the next closest unoccupied space at random. You can&rsquo;t bring any other creatures with you into the Drift this way, and multiple people using Drift harnesses simultaneously won&rsquo;t be anywhere near each other in the Drift during this time. You can&rsquo;t enter the Drift encumbered or overburdened, and the Drift harness will leave behind items you&rsquo;re carrying or wearing (besides itself) from bulkiest to lightest until you&rsquo;re no longer encumbered or overburdened. Until the beginning of your next turn, you&rsquo;re alone, floating freely in the Drift.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 14,
+    "modifiers": [
+      {
+        "_id": "62b76aa5-0478-4b49-944a-0ba540f7aff4",
+        "name": "Drift glass goggles",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "all-skills",
+        "enabled": false,
+        "max": -4,
+        "modifier": "-4",
+        "modifierType": "formula",
+        "notes": "While wearing Drift glass goggles, you have a –4 penalty to any vision-based skill or attack roll, but can see as if under the effects of a see invisibility spell. They also allow you to determine whether a creature normally visible to you is incorporeal.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "pro"
+      },
+      {
+        "_id": "496773b3-6964-47a4-908a-a91a4e9996ff",
+        "name": "Drift glass goggles",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "all-attacks",
+        "enabled": false,
+        "max": -4,
+        "modifier": "-4",
+        "modifierType": "formula",
+        "notes": "While wearing Drift glass goggles, you have a –4 penalty to any vision-based skill or attack roll, but can see as if under the effects of a see invisibility spell. They also allow you to determine whether a creature normally visible to you is incorporeal.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "acr"
+      }
+    ],
+    "price": 85000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "action",
+      "value": 50
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/drift_shell_i.json
+++ b/src/items/equipment/drift_shell_i.json
@@ -1,0 +1,165 @@
+{
+  "_id": "mxQ9pEqQC4cwe100",
+  "name": "Drift shell I",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -3,
+      "dex": 1,
+      "eac": 5,
+      "kac": 7,
+      "speedAdjust": -10
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 24
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "3",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 1,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Spectra parts can be fashioned into Drift shell suits, imbuing users with spectra-like grace; while in the Drift, the armor&rsquo;s armor check penalty is reduced by 2, its maximum Dexterity bonus increases by 1, and its speed adjustment becomes &ldquo;&mdash;.&rdquo;</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 3,
+    "modifiers": [],
+    "price": 1400,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 109",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/drift_shell_ii.json
+++ b/src/items/equipment/drift_shell_ii.json
@@ -1,0 +1,165 @@
+{
+  "_id": "OSnxVT09ZyzI7tju",
+  "name": "Drift shell II",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -3,
+      "dex": 2,
+      "eac": 10,
+      "kac": 12,
+      "speedAdjust": -10
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 36
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "3",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Spectra parts can be fashioned into Drift shell suits, imbuing users with spectra-like grace; while in the Drift, the armor&rsquo;s armor check penalty is reduced by 2, its maximum Dexterity bonus increases by 1, and its speed adjustment becomes &ldquo;&mdash;.&rdquo;</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 7,
+    "modifiers": [],
+    "price": 6500,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 109",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/drift_shell_iii.json
+++ b/src/items/equipment/drift_shell_iii.json
@@ -1,0 +1,165 @@
+{
+  "_id": "0yEVyNDOMMmgzW4t",
+  "name": "Drift shell III",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -3,
+      "dex": 3,
+      "eac": 16,
+      "kac": 18,
+      "speedAdjust": -10
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 48
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "3",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 3,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Spectra parts can be fashioned into Drift shell suits, imbuing users with spectra-like grace; while in the Drift, the armor&rsquo;s armor check penalty is reduced by 2, its maximum Dexterity bonus increases by 1, and its speed adjustment becomes &ldquo;&mdash;.&rdquo;</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 11,
+    "modifiers": [],
+    "price": 25250,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 109",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/drift_shell_iv.json
+++ b/src/items/equipment/drift_shell_iv.json
@@ -1,0 +1,165 @@
+{
+  "_id": "900F3pwdctir5gYF",
+  "name": "Drift shell IV",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -3,
+      "dex": 4,
+      "eac": 20,
+      "kac": 22,
+      "speedAdjust": -10
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 90
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "3",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 4,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Spectra parts can be fashioned into Drift shell suits, imbuing users with spectra-like grace; while in the Drift, the armor&rsquo;s armor check penalty is reduced by 2, its maximum Dexterity bonus increases by 1, and its speed adjustment becomes &ldquo;&mdash;.&rdquo;</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 15,
+    "modifiers": [],
+    "price": 113000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 109",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/drift_shell_v.json
+++ b/src/items/equipment/drift_shell_v.json
@@ -1,0 +1,165 @@
+{
+  "_id": "D5WUYQ298AceaWYi",
+  "name": "Drift shell V",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "heavy",
+      "acp": -3,
+      "dex": 5,
+      "eac": 25,
+      "kac": 25,
+      "speedAdjust": -10
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 102
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "3",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 5,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Spectra parts can be fashioned into Drift shell suits, imbuing users with spectra-like grace; while in the Drift, the armor&rsquo;s armor check penalty is reduced by 2, its maximum Dexterity bonus increases by 1, and its speed adjustment becomes &ldquo;&mdash;.&rdquo;</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 19,
+    "modifiers": [],
+    "price": 568000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 109",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/echo_gloves.json
+++ b/src/items/equipment/echo_gloves.json
@@ -1,0 +1,101 @@
+{
+  "_id": "AkUcn1FaJ1OmwriO",
+  "name": "Echo gloves",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "charge",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 9
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 20,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">These rugged gloves have thick, sensor-laden pads along the palms. When placed against a 10-foot surface (such as a floor or section of wall) and activated as a standard action, the gloves emit a sharp, seismic pulse, analyzes the rebounding waves, and publishes its analysis to a designated comm unit within 30 feet. The readout conveys the thickness of the analyzed 10-footsquare surface (to a maximum thickness of 5 feet), which might help identify weak points or hidden passages. It also grants you a +2 circumstance bonus to Engineering to assess stability and Perception checks to find hidden features in the surface. The pulse created is virtually imperceptible, though it&rsquo;s easily sensed by creatures that can sense the affected surface with blindsense (vibration) or blindsight (vibration).</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 4,
+    "modifiers": [
+      {
+        "_id": "d58720a3-386c-48a0-8630-7bd3a78d695b",
+        "name": "Echo gloves",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "Using the Echo gloves grants you a +2 circumstance bonus to Engineering to assess stability and Perception checks to find hidden features in the surface.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "per"
+      },
+      {
+        "_id": "dfe4bd32-5884-4a81-926e-26756d6410aa",
+        "name": "Echo gloves",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "Using the Echo gloves grants you a +2 circumstance bonus to Engineering to assess stability and Perception checks to find hidden features in the surface.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "eng"
+      }
+    ],
+    "price": 2000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 79",
+    "usage": {
+      "per": "action",
+      "value": 10
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/efreet_noble_regalia.json
+++ b/src/items/equipment/efreet_noble_regalia.json
@@ -1,0 +1,197 @@
+{
+  "_id": "3pXUNhRIJq84h5na",
+  "name": "Efreet Noble Regalia",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "power",
+      "acp": -4,
+      "dex": 2,
+      "eac": 25,
+      "kac": 28,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 99
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "62",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 4,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": true,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">As its name implies, sets of efreet noble regalia were originally crafted for powerful efreet on the Plane of Fire. Traditionally, the armor is decorated in shining red and gold, and has elaborate horned helms. While wearing this armor and while it still has charges remaining, you have fire resistance 20 and are immune to environmental effects related to heat. Additionally, when attacking with the armor&rsquo;s unarmed strikes or with any weapon slotted into the armor, you can make half the weapon&rsquo;s damage fire damage.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 18,
+    "modifiers": [
+      {
+        "_id": "c44ed057-5df4-483e-9e81-f007ba4c2667",
+        "name": "Efreet Noble Regalia",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": true,
+        "max": 20,
+        "modifier": "20",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "fire"
+      }
+    ],
+    "price": 417000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "10 ft.",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "size": "huge",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "30 ft., fly 30 ft. (average)",
+    "strength": 30,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "hour",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/enviro_mask.json
+++ b/src/items/equipment/enviro_mask.json
@@ -1,0 +1,70 @@
+{
+  "_id": "9JCQKYfGJ189EnHs",
+  "name": "Enviro mask",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This single-use clear mask, configurable to a wide range of species, can be found in safety kits throughout the galaxy. Whether it burns specialized salts or employs canisters of compressed gas, an enviro mask protects you from suffocation and inhaled hazards for 1 hour. It doesn&rsquo;t protect from other effects of vacuum or decompression, and it grants no benefit after 1 hour.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 1,
+    "modifiers": [],
+    "price": 75,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/feyguard_dryad.json
+++ b/src/items/equipment/feyguard_dryad.json
@@ -1,0 +1,165 @@
+{
+  "_id": "INDRxX7UeZTMAhSv",
+  "name": "Feyguard, dryad",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 7,
+      "eac": 12,
+      "kac": 13,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 48
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This armor gets its name from denizens of the First World, where the first sets were originally crafted. It&rsquo;s said that no two sets of feyguard armor are the same, either due to the First World&rsquo;s rapid fluctuations or the frequent alterations its mercurial fey manufacturers make on the production line. Feyguard is most commonly composed of materials that appear organically formed, and minor details seem to subtly shift in appearance during wear.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 11,
+    "modifiers": [],
+    "price": 24000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/feyguard_erlking.json
+++ b/src/items/equipment/feyguard_erlking.json
@@ -1,0 +1,165 @@
+{
+  "_id": "0UjhDyDAYyydi5AV",
+  "name": "Feyguard, erlking",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 9,
+      "eac": 20,
+      "kac": 21,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 102
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 4,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This armor gets its name from denizens of the First World, where the first sets were originally crafted. It&rsquo;s said that no two sets of feyguard armor are the same, either due to the First World&rsquo;s rapid fluctuations or the frequent alterations its mercurial fey manufacturers make on the production line. Feyguard is most commonly composed of materials that appear organically formed, and minor details seem to subtly shift in appearance during wear.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 19,
+    "modifiers": [],
+    "price": 555000,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/feyguard_nymph.json
+++ b/src/items/equipment/feyguard_nymph.json
@@ -1,0 +1,165 @@
+{
+  "_id": "7thotPMgO1NZdsEu",
+  "name": "Feyguard, nymph",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 8,
+      "eac": 17,
+      "kac": 18,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 90
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 3,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This armor gets its name from denizens of the First World, where the first sets were originally crafted. It&rsquo;s said that no two sets of feyguard armor are the same, either due to the First World&rsquo;s rapid fluctuations or the frequent alterations its mercurial fey manufacturers make on the production line. Feyguard is most commonly composed of materials that appear organically formed, and minor details seem to subtly shift in appearance during wear.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 15,
+    "modifiers": [],
+    "price": 97500,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/feyguard_sprite.json
+++ b/src/items/equipment/feyguard_sprite.json
@@ -1,0 +1,165 @@
+{
+  "_id": "PBEuAzhahqyoVJoA",
+  "name": "Feyguard, sprite",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "light",
+      "acp": null,
+      "dex": 6,
+      "eac": 7,
+      "kac": 8,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 36
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 0,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This armor gets its name from denizens of the First World, where the first sets were originally crafted. It&rsquo;s said that no two sets of feyguard armor are the same, either due to the First World&rsquo;s rapid fluctuations or the frequent alterations its mercurial fey manufacturers make on the production line. Feyguard is most commonly composed of materials that appear organically formed, and minor details seem to subtly shift in appearance during wear.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 7,
+    "modifiers": [],
+    "price": 6600,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "size": "",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "",
+    "strength": 0,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "",
+      "value": 0
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/flare_pistol_coruscator.json
+++ b/src/items/equipment/flare_pistol_coruscator.json
@@ -1,0 +1,255 @@
+{
+  "_id": "5ZMjll36hWudC6Sl",
+  "name": "Flare pistol, coruscator",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "flare",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 54
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 8,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 13,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Burn 2d6",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "3d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": true,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A more compact version of the flare rifle series, these pistols are especially useful for forays into the Shadow Plane.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 13,
+    "modifiers": [],
+    "price": 46000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": true,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": true,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 50
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "flame",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/flare_pistol_dazzler.json
+++ b/src/items/equipment/flare_pistol_dazzler.json
@@ -1,0 +1,255 @@
+{
+  "_id": "HiAtCF6wMnYg71LF",
+  "name": "Flare pistol, dazzler",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "flare",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 30
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 6,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 5,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Burn 1d6",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "1d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": true,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A more compact version of the flare rifle series, these pistols are especially useful for forays into the Shadow Plane.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 5,
+    "modifiers": [],
+    "price": 3300,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": true,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 40
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "flame",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/flare_pistol_nova.json
+++ b/src/items/equipment/flare_pistol_nova.json
@@ -1,0 +1,255 @@
+{
+  "_id": "pZyJekfVaSyb2kFd",
+  "name": "Flare pistol, nova",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "flare",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 102
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 12,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 19,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Burn 4d6",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "7d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": true,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A more compact version of the flare rifle series, these pistols are especially useful for forays into the Shadow Plane.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 19,
+    "modifiers": [],
+    "price": 485000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": true,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": true,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 60
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "flame",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/flare_pistol_scorcher.json
+++ b/src/items/equipment/flare_pistol_scorcher.json
@@ -1,0 +1,255 @@
+{
+  "_id": "TV81xerkQyUZTLPS",
+  "name": "Flare pistol, scorcher",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "flare",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 93
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 12,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 16,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Burn 3d6",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "5d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": true,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A more compact version of the flare rifle series, these pistols are especially useful for forays into the Shadow Plane.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 16,
+    "modifiers": [],
+    "price": 180000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": true,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": true,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 60
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "flame",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/flare_pistol_vivifier.json
+++ b/src/items/equipment/flare_pistol_vivifier.json
@@ -1,0 +1,255 @@
+{
+  "_id": "tzwbvS00mqcdz4B8",
+  "name": "Flare pistol, vivifier",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "flare",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 42
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 6,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 9,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Burn 1d6",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": true,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A more compact version of the flare rifle series, these pistols are especially useful for forays into the Shadow Plane.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 9,
+    "modifiers": [],
+    "price": 13000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": true,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 50
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "flame",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/hollowed_drums_mk_1.json
+++ b/src/items/equipment/hollowed_drums_mk_1.json
@@ -1,0 +1,107 @@
+{
+  "_id": "5BBbTE9KbIt4HIxx",
+  "name": "Hollowed drums Mk 1",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Hollowed drums are inserted into your ears and replace the standard eardrums of your species. This necrograft can be activated or deactivated as a swift action. When activated, it deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a &ndash;2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as </span><span class=\"fontstyle2\">suggestion</span><span class=\"fontstyle0\">) that vary based on the model.</span></p>\n<p><span class=\"fontstyle0\">Mk 1 hollowed drums grant a +1 enhancement save bonus and sonic resistance 2.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>Sonic resistance must be toggled on/off in the Modifiers tab.</em></span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 1,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": -2,
+        "modifier": "-2",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "per"
+      },
+      {
+        "_id": "6238ec8f-17e8-448a-939d-5e0127776070",
+        "name": "Hollowed drums",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": true,
+        "max": 1,
+        "modifier": "1",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": ""
+      },
+      {
+        "_id": "be3b8a65-e1f6-41a7-973d-1485af138f73",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "constant",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "sonic"
+      }
+    ],
+    "price": 200,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "ears"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/hollowed_drums_mk_2.json
+++ b/src/items/equipment/hollowed_drums_mk_2.json
@@ -1,0 +1,107 @@
+{
+  "_id": "ASbUUOiobMX6NN5F",
+  "name": "Hollowed drums Mk 2",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 11
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Hollowed drums are inserted into your ears and replace the standard eardrums of your species. This necrograft can be activated or deactivated as a swift action. When activated, it deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a &ndash;2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as </span><span class=\"fontstyle2\">suggestion</span><span class=\"fontstyle0\">) that vary based on the model. </span></p>\n<p><span class=\"fontstyle0\">Mk 2 hollowed drums grant a +1 enhancement save bonus and sonic resistance 5.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>Sonic resistance must be toggled on/off in the Modifiers tab.</em></span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 6,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": -2,
+        "modifier": "-2",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "per"
+      },
+      {
+        "_id": "6238ec8f-17e8-448a-939d-5e0127776070",
+        "name": "Hollowed drums",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": true,
+        "max": 1,
+        "modifier": "1",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": ""
+      },
+      {
+        "_id": "be3b8a65-e1f6-41a7-973d-1485af138f73",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 5,
+        "modifier": "5",
+        "modifierType": "constant",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "sonic"
+      }
+    ],
+    "price": 4000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "ears"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/hollowed_drums_mk_3.json
+++ b/src/items/equipment/hollowed_drums_mk_3.json
@@ -1,0 +1,107 @@
+{
+  "_id": "5bPtDUjeLST75psL",
+  "name": "Hollowed drums Mk 3",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 17
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Hollowed drums are inserted into your ears and replace the standard eardrums of your species. This necrograft can be activated or deactivated as a swift action. When activated, it deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a &ndash;2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as </span><span class=\"fontstyle2\">suggestion</span><span class=\"fontstyle0\">) that vary based on the model. </span></p>\n<p><span class=\"fontstyle0\">Mk 3 hollowed drums grant a +2 enhancement save bonus and sonic resistance 8.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>Sonic resistance must be toggled on/off in the Modifiers tab.</em></span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 12,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": -2,
+        "modifier": "-2",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "per"
+      },
+      {
+        "_id": "6238ec8f-17e8-448a-939d-5e0127776070",
+        "name": "Hollowed drums",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": true,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": ""
+      },
+      {
+        "_id": "be3b8a65-e1f6-41a7-973d-1485af138f73",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 8,
+        "modifier": "8",
+        "modifierType": "constant",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "sonic"
+      }
+    ],
+    "price": 30000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "ears"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/hollowed_drums_mk_4.json
+++ b/src/items/equipment/hollowed_drums_mk_4.json
@@ -1,0 +1,107 @@
+{
+  "_id": "8uCz1cynNryau54K",
+  "name": "Hollowed drums Mk 4",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 53
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Hollowed drums are inserted into your ears and replace the standard eardrums of your species. This necrograft can be activated or deactivated as a swift action. When activated, it deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a &ndash;2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as </span><span class=\"fontstyle2\">suggestion</span><span class=\"fontstyle0\">) that vary based on the model. </span></p>\n<p><span class=\"fontstyle0\">Mk 4 hollowed drums grant a +3 enhancement save bonus and sonic resistance 15.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>Sonic resistance must be toggled on/off in the Modifiers tab.</em></span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 18,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": true,
+        "max": -2,
+        "modifier": "-2",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "per"
+      },
+      {
+        "_id": "6238ec8f-17e8-448a-939d-5e0127776070",
+        "name": "Hollowed drums",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": true,
+        "max": 3,
+        "modifier": "3",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": ""
+      },
+      {
+        "_id": "be3b8a65-e1f6-41a7-973d-1485af138f73",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 15,
+        "modifier": "15",
+        "modifierType": "constant",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a –2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "sonic"
+      }
+    ],
+    "price": 350000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "ears"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/hollowed_drums_mk_5.json
+++ b/src/items/equipment/hollowed_drums_mk_5.json
@@ -1,0 +1,92 @@
+{
+  "_id": "9L0riBEeDBqhbFJ5",
+  "name": "Hollowed drums Mk 5",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 55
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Hollowed drums are inserted into your ears and replace the standard eardrums of your species. This necrograft can be activated or deactivated as a swift action. When activated, it deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, a &ndash;2 penalty to sound-based Perception checks, and a bonus to saving throws against mind-affecting effects with an auditory component (such as </span><span class=\"fontstyle2\">suggestion</span><span class=\"fontstyle0\">) that vary based on the model. </span></p>\n<p><span class=\"fontstyle0\">Mk 5 hollowed drums grant a +3 enhancement save bonus, sonic resistance 20, and grant no penalty to Perception checks while active.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>Sonic resistance must be toggled on/off in the Modifiers tab.</em></span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 20,
+    "modifiers": [
+      {
+        "_id": "6238ec8f-17e8-448a-939d-5e0127776070",
+        "name": "Hollowed drums",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": true,
+        "max": 3,
+        "modifier": "3",
+        "modifierType": "formula",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": ""
+      },
+      {
+        "_id": "be3b8a65-e1f6-41a7-973d-1485af138f73",
+        "name": "Hollowed drums",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 20,
+        "modifier": "20",
+        "modifierType": "constant",
+        "notes": "When activated, Hollowed drums deadens sounds you hear, reducing their volume and emotional impact to grant you sonic resistance, and a bonus to saving throws against mind-affecting effects with an auditory component (such as suggestion).",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "sonic"
+      }
+    ],
+    "price": 775000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "ears"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/interplanar_comm_unit_inner_sphere.json
+++ b/src/items/equipment/interplanar_comm_unit_inner_sphere.json
@@ -1,0 +1,71 @@
+{
+  "_id": "cTs6QzKPFMyGQDKd",
+  "name": "Interplanar comm unit, Inner Sphere",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 51
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "60",
+    "capacity": {
+      "max": 2,
+      "value": 2
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Comm units capable of piercing the barriers between planes are rare. Such marvels of hybrid technology are typically controlled by powerful organizations, and their use is closely monitored. An </span><span class=\"fontstyle2\">interplanar comm unit </span><span class=\"fontstyle0\">can communicate only with other </span><span class=\"fontstyle2\">interplanar comm units </span><span class=\"fontstyle0\">that are on a single specific plane, and it can send or receive only two messages per day.</span></p>\n<p><span class=\"fontstyle4\"><strong>Inner Sphere (Level 16):</strong> </span><span class=\"fontstyle0\">These can send and receive transmissions between two of the following: the Material Plane, Elemental Planes, Ethereal Plane, First World, Negative Energy Plane, Positive Energy Plane, and Shadow Plane.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 16,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 160000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "day",
+      "value": 2
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/interplanar_comm_unit_outer_sphere.json
+++ b/src/items/equipment/interplanar_comm_unit_outer_sphere.json
@@ -1,0 +1,71 @@
+{
+  "_id": "WiWXGtWiFGxNo6kS",
+  "name": "Interplanar comm unit, Outer Sphere",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 55
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "100",
+    "capacity": {
+      "max": 2,
+      "value": 2
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Comm units capable of piercing the barriers between planes are rare. Such marvels of hybrid technology are typically controlled by powerful organizations, and their use is closely monitored. An </span><span class=\"fontstyle2\">interplanar comm unit </span><span class=\"fontstyle0\">can communicate only with other </span><span class=\"fontstyle2\">interplanar comm units </span><span class=\"fontstyle0\">that are on a single specific plane, and it can send or receive only two messages per day.</span></p>\n<p><span class=\"fontstyle4\"><strong>Outer Sphere (Level 20):&nbsp;</strong></span><span class=\"fontstyle0\">These units are rarer still. These can send and receive transmissions between two of the following: the Material Plane, Abaddon, the Abyss, the Astral Plane, Axis, the Boneyard, Elysium, Heaven, Hell, the Maelstrom, and Nirvana.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 20,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 880000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "day",
+      "value": 2
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/jewelry_couture.json
+++ b/src/items/equipment/jewelry_couture.json
@@ -1,0 +1,74 @@
+{
+  "_id": "X2PZYD8P08oIrxK6",
+  "name": "Jewelry, couture",
+  "type": "goods",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 13
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Couture jewelry is often produced in extremely limited runs, and the most expensive pieces are one-of-a-kind creations for wealthy clients. Wearing couture jewelry grants a +1 circumstance bonus on Charisma-based checks to influence creatures who are aware of the value of the items, as determined by the GM. If you are also wearing couture clothing, the bonuses stack. The price given is for one piece of jewelry. Bonuses from wearing more than one piece of jewelry do not stack.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 7,
+    "modifiers": [
+      {
+        "_id": "64b25a94-e835-4c51-91e7-9f12200486de",
+        "name": "Jewelry, couture",
+        "type": "circumstance",
+        "condition": "",
+        "container": {
+          "actorId": "Qs2gOWidvlhDWFVK",
+          "itemId": "F1nW6zVvXFXt6wk3"
+        },
+        "effectType": "ability-skills",
+        "enabled": false,
+        "max": 1,
+        "modifier": "1",
+        "modifierType": "formula",
+        "notes": "Wearing couture jewelry grants a +1 circumstance bonus on Charisma-based checks to influence creatures who are aware of the value of the items, as determined by the GM. Bonuses from wearing more than one piece of jewelry do not stack.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "cha"
+      }
+    ],
+    "price": 500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 129"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/jewelry_designer.json
+++ b/src/items/equipment/jewelry_designer.json
@@ -1,0 +1,54 @@
+{
+  "_id": "05CkdsnLRG1lkknv",
+  "name": "Jewelry, designer",
+  "type": "goods",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 8
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Jewelry pieces are personal adornments often made of real (or synthetic) precious metals and stones. Common pieces include necklaces, piercings, hair decorations, rings, and bracelets. Among some species, other adornments like scale, horn, or ridge piercings are popular. Designer jewelry is associated with a specific designer. The price given is for one piece of jewelry.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 3,
+    "modifiers": [],
+    "price": 50,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 129"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/machimind.json
+++ b/src/items/equipment/machimind.json
@@ -1,0 +1,70 @@
+{
+  "_id": "C864T4d1Qsxt3BsK",
+  "name": "Machimind",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "charge",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 9
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "capacity": {
+      "max": 20,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This lattice of wires and sensors is worn atop the head. You can activate or deactivate a machimind as a swift action. While worn and active, a machimind lets you telepathically communicate with creatures within 60 feet that have machine telepathy or the technological subtype. You can also communicate through unprotected technological devices (or those to which you already have access), such as a datapad or comm unit, at a range of 30 feet.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 4,
+    "modifiers": [],
+    "price": 2000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 61",
+    "usage": {
+      "per": "minute",
+      "value": 2
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/matter_converter_mk_1.json
+++ b/src/items/equipment/matter_converter_mk_1.json
@@ -1,0 +1,71 @@
+{
+  "_id": "lMm359N6NJ3UNF0i",
+  "name": "Matter converter Mk 1",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 12
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This empty box is 1-foot square and lined with glass panels and steel plates. As a full action, you can seal a consumable item (such as a grenade or serum) into the box and activate it. Once activated, the </span><span class=\"fontstyle2\">matter converter </span><span class=\"fontstyle0\">destroys the object sealed inside the box, consuming it in a black void, and then </span><span class=\"fontstyle0\">creates a new consumable item in its place. This new item must have an item level up to one level lower than the item consumed by the </span><span class=\"fontstyle2\">matter converter</span><span class=\"fontstyle0\">, with a maximum level based on its type. A </span><span class=\"fontstyle2\">mk 1 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than level 5. A </span><span class=\"fontstyle2\">mk 2 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than 10. A </span><span class=\"fontstyle2\">mk 3 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than 15.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">matter converter </span><span class=\"fontstyle0\">takes 1 round per level of the created item to generate the replacement item. An item created in this way is of average quality and has the statistics for an ordinary item of its type.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 7,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 7000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 92",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/matter_converter_mk_2.json
+++ b/src/items/equipment/matter_converter_mk_2.json
@@ -1,0 +1,71 @@
+{
+  "_id": "KOLd1WhOfQqBvJdq",
+  "name": "Matter converter Mk 2",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 17
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This empty box is 1-foot square and lined with glass panels and steel plates. As a full action, you can seal a consumable item (such as a grenade or serum) into the box and activate it. Once activated, the </span><span class=\"fontstyle2\">matter converter </span><span class=\"fontstyle0\">destroys the object sealed inside the box, consuming it in a black void, and then </span><span class=\"fontstyle0\">creates a new consumable item in its place. This new item must have an item level up to one level lower than the item consumed by the </span><span class=\"fontstyle2\">matter converter</span><span class=\"fontstyle0\">, with a maximum level based on its type. A </span><span class=\"fontstyle2\">mk 1 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than level 5. A </span><span class=\"fontstyle2\">mk 2 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than 10. A </span><span class=\"fontstyle2\">mk 3 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than 15.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">matter converter </span><span class=\"fontstyle0\">takes 1 round per level of the created item to generate the replacement item. An item created in this way is of average quality and has the statistics for an ordinary item of its type.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 12,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 38000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 92",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/matter_converter_mk_3.json
+++ b/src/items/equipment/matter_converter_mk_3.json
@@ -1,0 +1,71 @@
+{
+  "_id": "9zUuzC4o2d94PMuP",
+  "name": "Matter converter Mk 3",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 52
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This empty box is 1-foot square and lined with glass panels and steel plates. As a full action, you can seal a consumable item (such as a grenade or serum) into the box and activate it. Once activated, the </span><span class=\"fontstyle2\">matter converter </span><span class=\"fontstyle0\">destroys the object sealed inside the box, consuming it in a black void, and then </span><span class=\"fontstyle0\">creates a new consumable item in its place. This new item must have an item level up to one level lower than the item consumed by the </span><span class=\"fontstyle2\">matter converter</span><span class=\"fontstyle0\">, with a maximum level based on its type. A </span><span class=\"fontstyle2\">mk 1 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than level 5. A </span><span class=\"fontstyle2\">mk 2 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than 10. A </span><span class=\"fontstyle2\">mk 3 matter converter </span><span class=\"fontstyle0\">can create an item with a level no higher than 15.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">matter converter </span><span class=\"fontstyle0\">takes 1 round per level of the created item to generate the replacement item. An item created in this way is of average quality and has the statistics for an ordinary item of its type.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 17,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 270000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 92",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/metaphysical_detector_mk_i.json
+++ b/src/items/equipment/metaphysical_detector_mk_i.json
@@ -1,0 +1,70 @@
+{
+  "_id": "p2vAh8S2rUvDuOBY",
+  "name": "Metaphysical detector, Mk I",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 10
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This one-handed device can be held in front of you and activated as a swift action. The MPD indicates the distance to the closest entity with the trait determined by its style below. The MPD has a range of 100 feet and doesn&rsquo;t indicate a direction, so you must move around to triangulate a specific location. Since it detects only the closest creature, it can be confused by multiple entities.</span></p>\n<p><span class=\"fontstyle0\"><strong><span class=\"fontstyle2\">Mk I (Level 5): </span></strong><span class=\"fontstyle3\">Detects incorporeal beings</span> <br style=\"font-style: normal; font-variant: normal; font-weight: normal; letter-spacing: normal; line-height: normal; orphans: 2; text-align: -webkit-auto; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px;\" /></span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 1,
+    "identified": false,
+    "level": 5,
+    "modifiers": [],
+    "price": 2950,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/metaphysical_detector_mk_ii.json
+++ b/src/items/equipment/metaphysical_detector_mk_ii.json
@@ -1,0 +1,70 @@
+{
+  "_id": "9PKw0pXyvP8iAPkK",
+  "name": "Metaphysical detector, Mk II",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 13
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This one-handed device can be held in front of you and activated as a swift action. The MPD indicates the distance to the closest entity with the trait determined by its style below. The MPD has a range of 100 feet and doesn&rsquo;t indicate a direction, so you must move around to triangulate a specific location. Since it detects only the closest creature, it can be confused by multiple entities.</span></p>\n<p><span class=\"fontstyle0\"><span class=\"fontstyle0\"><strong>Mk II (Level 8):</strong> </span><span class=\"fontstyle2\">Detects incorporeal, invisible beings, or beings with both traits, your choice.</span><br style=\"font-style: normal; font-variant: normal; font-weight: normal; letter-spacing: normal; line-height: normal; orphans: 2; text-align: -webkit-auto; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px;\" /></span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 1,
+    "identified": false,
+    "level": 8,
+    "modifiers": [],
+    "price": 8500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/mood_goo_emitter.json
+++ b/src/items/equipment/mood_goo_emitter.json
@@ -1,0 +1,239 @@
+{
+  "_id": "j3W86e5nVG7ccau8",
+  "name": "Mood goo emitter",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "moodGoo",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 27
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 10,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 4,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Knockdown",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Immediately after the Crash, deep in the warrens of Absalom Station, space goblins discovered a tiny rupture to the Drift emitting a strange, purplish slime. Physical contact with this slime was found to cause a pleasant, calming euphoria. While this &ldquo;mood goo&rdquo; dries after a minute, it can be stored under pressure. The goblins immediately packed this self-replicating substance into insulation foam sprayers and started selling them as riot control gear. These mood goo emitters can fire the mood goo in a line up to 30 feet, allowing their user to select up to 4 squares in that line to become difficult terrain for 1 minute. Any creature hit by the goo gains the fascinated condition for 1d6 rounds, (DC 14 Will save negates). Being sprayed with additional goo doesn&rsquo;t count as a threat for the fascinated condition and adds to the duration of the original effect, up to 10 rounds maximum. A creature that succeeds at this save is immune to the effects of mood goo for 24 hours.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 4,
+    "modifiers": [],
+    "price": 2500,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": true,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": true,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 30
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "will",
+      "dc": "14",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/mood_goo_tank.json
+++ b/src/items/equipment/mood_goo_tank.json
@@ -1,0 +1,75 @@
+{
+  "_id": "P1TIkNnCdIiX0BqV",
+  "name": "Mood goo tank",
+  "type": "ammunition",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "moodGoo",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 10,
+      "value": 10
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p>Immediately after the Crash, deep in the warrens of Absalom Station, space goblins discovered a tiny rupture to the Drift emitting a strange, purplish slime. Physical contact with this slime was found to cause a pleasant, calming euphoria. While this &ldquo;mood goo&rdquo; dries after a minute, it can be stored under pressure. The goblins immediately packed this self-replicating substance into insulation foam sprayers and started selling them as riot control gear.</p>\n<p><strong>Capacity:</strong>&nbsp;10</p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 1,
+    "price": 250,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 51",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "useCapacity": true
+  },
+  "img": "systems/sfrpg/icons/equipment/technological%20items/chemalyzer.webp"
+}

--- a/src/items/equipment/nano_gadget_loadout_(belt).json
+++ b/src/items/equipment/nano_gadget_loadout_(belt).json
@@ -1,0 +1,83 @@
+{
+  "_id": "IgNIdNRmddAm7HOj",
+  "name": "Nano gadget loadout (belt)",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 13
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "technological",
+            "goods"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 5,
+          "subtype": "",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Nano gadget loadouts incorporate technological or personal items into their shape while appearing otherwise ordinary. You can&rsquo;t integrate weapons, armor, hybrid items, or magical items into the loadout. Pulling out one of the gadgets requires a swift action. Nano gadget loadouts can hold only items purchased at the same time as the loadout or items configured to be used with it (at a cost of UPBs equal to 10% of the item&rsquo;s price). The loadout type indicates the number of items that fit, and the total levels of all items can&rsquo;t exceed the level of the loadout.</span></p>\n<p><span class=\"fontstyle0\"><strong>Belt (Level 8):</strong> </span><span class=\"fontstyle2\">Can contain up to 5 items with light or negligible bulk.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 8,
+    "modifiers": [],
+    "price": 9650,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/nano_gadget_loadout_(duster).json
+++ b/src/items/equipment/nano_gadget_loadout_(duster).json
@@ -1,0 +1,83 @@
+{
+  "_id": "Hjzgs60bjQWQJ99e",
+  "name": "Nano gadget loadout (duster)",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 17
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "bulk",
+          "acceptsType": [
+            "technological",
+            "goods"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 2,
+          "subtype": "",
+          "weightMultiplier": 1,
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Nano gadget loadouts incorporate technological or personal items into their shape while appearing otherwise ordinary. You can&rsquo;t integrate weapons, armor, hybrid items, or magical items into the loadout. Pulling out one of the gadgets requires a swift action. Nano gadget loadouts can hold only items purchased at the same time as the loadout or items configured to be used with it (at a cost of UPBs equal to 10% of the item&rsquo;s price). The loadout type indicates the number of items that fit, and the total levels of all items can&rsquo;t exceed the level of the loadout.</span></p>\n<p><span class=\"fontstyle0\"><strong>Duster (Level 12):</strong> </span><span class=\"fontstyle2\">Can contain items totaling up to 2 bulk (maximum of 4 items with light bulk and 4 items with negligible bulk).</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 12,
+    "modifiers": [],
+    "price": 35400,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/nano_gadget_loadout_(wristband).json
+++ b/src/items/equipment/nano_gadget_loadout_(wristband).json
@@ -1,0 +1,83 @@
+{
+  "_id": "MJfnW43CaNflvNKA",
+  "name": "Nano gadget loadout (wristband)",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 10
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "technological",
+            "goods"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 3,
+          "subtype": "",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Nano gadget loadouts incorporate technological or personal items into their shape while appearing otherwise ordinary. You can&rsquo;t integrate weapons, armor, hybrid items, or magical items into the loadout. Pulling out one of the gadgets requires a swift action. Nano gadget loadouts can hold only items purchased at the same time as the loadout or items configured to be used with it (at a cost of UPBs equal to 10% of the item&rsquo;s price). The loadout type indicates the number of items that fit, and the total levels of all items can&rsquo;t exceed the level of the loadout.</span></p>\n<p><span class=\"fontstyle0\"><span class=\"fontstyle0\"><strong>Wristband (Level 5):</strong> </span><span class=\"fontstyle2\">Can contain up to 3 items of negligible bulk.</span></span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 5,
+    "modifiers": [],
+    "price": 3100,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 53",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/oblivion_chassis.json
+++ b/src/items/equipment/oblivion_chassis.json
@@ -1,0 +1,181 @@
+{
+  "_id": "jr7DdrwNVBcOaH25",
+  "name": "Oblivion Chassis",
+  "type": "equipment",
+  "data": {
+    "type": "",
+    "ability": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "",
+      "value": null
+    },
+    "armor": {
+      "type": "power",
+      "acp": -4,
+      "dex": 3,
+      "eac": 18,
+      "kac": 23,
+      "speedAdjust": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 54
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "36",
+    "capacity": {
+      "max": 100,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "upgrade",
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "armorUpgrade",
+          "weightProperty": "slots"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "weapon"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "weaponSlot",
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": true,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This powered, magical armor was originally constructed in the forges of Abaddon. While primarily battery-powered, it also converts soul energy into auxiliary power. Whenever a significant enemy dies within 30 feet of an operating </span><span class=\"fontstyle2\">oblivion chassis</span><span class=\"fontstyle0\">, the armor gains a number of soul charges equal to the dead creature&rsquo;s CR. As a standard action, you can spend 10 soul charges to cast the spell </span><span class=\"fontstyle2\">supercharge weapon </span><span class=\"fontstyle0\">on the armor&rsquo;s unarmed strikes or a weapon in one of the armor&rsquo;s weapon slots.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": null
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 13,
+    "modifiers": [],
+    "price": 57150,
+    "proficient": false,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "",
+      "value": null
+    },
+    "reach": "",
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "size": "large",
+    "source": "DC pg. 52",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "speed": "30 ft.",
+    "strength": 25,
+    "target": {
+      "type": "",
+      "value": null
+    },
+    "usage": {
+      "per": "minute",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": null,
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/partitioned_personality_module.json
+++ b/src/items/equipment/partitioned_personality_module.json
@@ -1,0 +1,77 @@
+{
+  "_id": "pDf9cSykKPxeGy8F",
+  "name": "Partitioned personality module",
+  "type": "augmentation",
+  "data": {
+    "type": "cybernetic",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 12
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Initially developed as a device to closely monitor organic cerebral activity, these neural implants study the brain activity of the host and then design an artificial copy of their thought patterns, decision trees, and emotional profile. This artificial personality serves as a backup for the host that bolsters their mental faculties and can be activated when psychic attacks disrupt their free will. You gain a +2 enhancement bonus to saves against charm, compulsion, or mind-affecting effects. Once per day when you fail a save against a charm, compulsion, or mind-affecting effect, you can activate your backup personality by spending a Resolve Point to immediately reroll the save and take the new result.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 7,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Partitioned personality module",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "You gain a +2 enhancement bonus to saves against charm, compulsion, or mind-affecting effects.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 6800,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 87",
+    "system": "eyes"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/perfume_designer.json
+++ b/src/items/equipment/perfume_designer.json
@@ -1,0 +1,74 @@
+{
+  "_id": "SPSehYTuehx9UbMN",
+  "name": "Perfume, designer",
+  "type": "goods",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 8
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Designer perfumes are fragrances associated with designers and are generally far more expensive than standard varieties. Wearing designer perfume grants you a +1 circumstance bonus on Diplomacy checks against creatures that find the scent pleasing, as determined by the GM.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 3,
+    "modifiers": [
+      {
+        "_id": "64b25a94-e835-4c51-91e7-9f12200486de",
+        "name": "Perfume, designer",
+        "type": "circumstance",
+        "condition": "",
+        "container": {
+          "actorId": "Qs2gOWidvlhDWFVK",
+          "itemId": "F1nW6zVvXFXt6wk3"
+        },
+        "effectType": "skill",
+        "enabled": false,
+        "max": 1,
+        "modifier": "1",
+        "modifierType": "formula",
+        "notes": "Wearing designer perfume grants you a +1 circumstance bonus on Diplomacy checks against creatures that find the scent pleasing, as determined by the GM.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "dip"
+      }
+    ],
+    "price": 350,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 129"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/planar_acclimation_serum.json
+++ b/src/items/equipment/planar_acclimation_serum.json
@@ -1,0 +1,120 @@
+{
+  "_id": "Uggu71crC5SqvET3",
+  "name": "Planar acclimation serum",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This single-use serum is designed to acclimate you to any non-Drift plane besides the Material Plane. For 1 hour, you lose the extraplanar subtype and count as a native of the plane you&rsquo;re currently on for the purpose of divination magic and how planar traits affect you. This has no effect in the Drift.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 10,
+    "modifiers": [],
+    "price": 3400,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 54",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/potion-flask-corked-cyan.webp"
+}

--- a/src/items/equipment/planar_flare.json
+++ b/src/items/equipment/planar_flare.json
@@ -1,0 +1,71 @@
+{
+  "_id": "LuOL40pTKuRZhLP5",
+  "name": "Planar flare",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 1,
+      "value": 1
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">These single-use emergency signaling devices have been developed since the Drift Crash and issued to starship crews who might find themselves stranded. Individuals lost in the Drift might attempt to craft a </span><span class=\"fontstyle2\">planar flare </span><span class=\"fontstyle0\">to signal for help.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">planar flare </span><span class=\"fontstyle0\">is a pistol-shaped device that can store a single visual image such as a night sky, landmark, or map. The flare can be used to take this image, functioning as a digital camera, or the image can be uploaded from a personal comm. Once an image has been stored in the flare, the device can be set to transmit that image to one location anywhere in the galaxy. When used as a standard action, a </span><span class=\"fontstyle2\">planar flare </span><span class=\"fontstyle0\">emits a burst of planar energy and is reduced to dust, as magic sends the image through the Plane of Fire (or another plane) to its programmed destination. The stored image travels to its destination in 1d6+6 days. When it reaches the destination, the image appears, filling an area 30 feet in diameter for 1 minute before vanishing.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">planar flare </span><span class=\"fontstyle0\">can be used as a small arm, dealing 1d6 fire damage. When used in this way, a </span><span class=\"fontstyle2\">planar flare </span><span class=\"fontstyle0\">has a range increment of 15 feet and the critical hit effect burn 1d4. A </span><span class=\"fontstyle2\">planar flare </span><span class=\"fontstyle0\">is consumed upon use.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 1,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 75,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 93",
+    "usage": {
+      "per": "shot",
+      "value": 1
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/planar_lenses.json
+++ b/src/items/equipment/planar_lenses.json
@@ -1,0 +1,77 @@
+{
+  "_id": "RRMeewPu6WyBTI7h",
+  "name": "Planar lenses",
+  "type": "augmentation",
+  "data": {
+    "type": "magitech",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 50
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This augmentation consists of thin layers of planar material inserted into a creature&rsquo;s eyes. When you purchase or craft a set of planar lenses, you choose a plane that&rsquo;s coterminous with the Material Plane: the Ethereal Plane, the First World, or the Shadow Plane. As a move action, you can activate these lenses to see into that plane. You can deactivate the lenses as a move action.</span></p>\n<p><span class=\"fontstyle0\">While active, the lenses allow you to see the plane at the location where it corresponds with your current location on the Material Plane. The viewed plane&rsquo;s surroundings appear to overlap with your surroundings on the Material Plane, giving you a &ndash;10 penalty on sight-based Perception checks to notice activity on the Material Plane while the lenses are active. You can see only 60 feet into the viewed plane, regardless of your normal range of vision. If you&rsquo;re on the plane that corresponds with your lens model, you can use the lenses to view the Material Plane; otherwise, the lenses don&rsquo;t function unless you&rsquo;re on the Material Plane.</span></p>\n<p><span class=\"fontstyle0\">You can activate the lenses once per day; additional uses per day cost 1 Resolve Point each. Each activation lasts for 1 minute.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 15,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Planar lenses",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": -10,
+        "modifier": "-10",
+        "modifierType": "formula",
+        "notes": "You have a –10 penalty on sight-based Perception checks to notice activity on the Material Plane while the Planar lenses are active.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "per"
+      }
+    ],
+    "price": 122000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 112",
+    "system": "eyes"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/planar_spacesuit.json
+++ b/src/items/equipment/planar_spacesuit.json
@@ -1,0 +1,101 @@
+{
+  "_id": "DnCTw25c59huxsO0",
+  "name": "Planar spacesuit",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 10
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">When you purchase a planar suit, choose one plane: astral, elemental (air, earth, fire, or water), ethereal, negative energy, positive energy, or shadow. This spacesuit (</span><span class=\"fontstyle2\">Core Rulebook </span><span class=\"fontstyle0\">231), designed for surviving and traveling in its designated plane, grants you a +4 circumstance bonus to skill checks and saving throws related to surviving that plane&rsquo;s environmental dangers.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 5,
+    "modifiers": [
+      {
+        "_id": "dcfa7245-5637-4be4-99b1-4da285544003",
+        "name": "Planar spacesuit",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "all-skills",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "Grants you a +4 circumstance bonus to skill checks and saving throws related to surviving the plane’s environmental dangers that the spacesuit is designed for.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": ""
+      },
+      {
+        "_id": "ec40b6bf-bb0c-4d5a-a780-9208a239a447",
+        "name": "Planar spacesuit",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "Grants you a +4 circumstance bonus to skill checks and saving throws related to surviving the plane’s environmental dangers that the spacesuit is designed for.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": ""
+      }
+    ],
+    "price": 2750,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 54",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/probability_tendril_mk_1.json
+++ b/src/items/equipment/probability_tendril_mk_1.json
@@ -1,0 +1,61 @@
+{
+  "_id": "LHgtI1aiyiE7OZEc",
+  "name": "Probability tendril Mk 1",
+  "type": "augmentation",
+  "data": {
+    "type": "biotech",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 12
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">One of your hands is replaced by a lab-grown protean tendril that allows you to replicate a protean&rsquo;s chaotic powers. As a standard action, you can spend 1 Resolve Point to target a creature within 30 feet and force it to succeed at a Fortitude save (DC = 10 + half your level + your Constitution modifier) or be affected by a random effect from the table below.</span></p>\n<p><span class=\"fontstyle0\">You can choose not to spend a Resolve Point before you use this ability, but doing so requires you to succeed at the same save or be subject to the same effect. The augmentation&rsquo;s </span><span class=\"fontstyle0\">model determines which die you roll on the following table to determine the random effect.</span></p>\n<p><span class=\"fontstyle2\"><strong>Mk 1:</strong> </span><span class=\"fontstyle0\">Roll 1d4 on the table.</span></p>\n<table class=\"NormalTable\" style=\"font-family: var(--font-primary); font-size: var(--font-size-14);\">\n<tbody>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle0\">D10 </span></td>\n<td width=\"200\"><span class=\"fontstyle0\">EFFECT</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">1 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is nauseated for 1 round</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">2 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains resistance 10 to a random energy type (acid, cold, electricity, fire, or sonic) for the next 10 minutes</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">3 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target takes 8d6 damage of a random energy type (acid, cold, electricity, fire, or sonic), or half as much on a successful save</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">4 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target regains 4d8 Hit Points</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">5 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains a climb, fly, or swim speed (determined randomly) equal to its land speed for 10 minutes</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">6 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is affected by a </span><span class=\"fontstyle3\">restoration </span><span class=\"fontstyle2\">spell</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">7 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is confused for 1d4 rounds</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">8 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains 1d4 negative levels</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">9 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is affected by </span><span class=\"fontstyle3\">baleful polymorph </span><span class=\"fontstyle2\">(level 6); its polymorphed form is random</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">10 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target&rsquo;s head is wracked with pain, dealing 18d6 damage (half on a successful save)</span></td>\n</tr>\n</tbody>\n</table>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 7,
+    "modifiers": [],
+    "price": 6250,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 112",
+    "system": "hand"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/probability_tendril_mk_2.json
+++ b/src/items/equipment/probability_tendril_mk_2.json
@@ -1,0 +1,61 @@
+{
+  "_id": "PsDej4JQdkrlDsPd",
+  "name": "Probability tendril Mk 2",
+  "type": "augmentation",
+  "data": {
+    "type": "biotech",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 16
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">One of your hands is replaced by a lab-grown protean tendril that allows you to replicate a protean&rsquo;s chaotic powers. As a standard action, you can spend 1 Resolve Point to target a creature within 30 feet and force it to succeed at a Fortitude save (DC = 10 + half your level + your Constitution modifier) or be affected by a random effect from the table below.</span></p>\n<p><span class=\"fontstyle0\">You can choose not to spend a Resolve Point before you use this ability, but doing so requires you to succeed at the same save or be subject to the same effect. The augmentation&rsquo;s </span><span class=\"fontstyle0\">model determines which die you roll on the following table to determine the random effect.</span></p>\n<p><strong><span class=\"fontstyle2\">Mk 2: </span></strong><span class=\"fontstyle0\">Roll 1d8 on the table.</span></p>\n<table class=\"NormalTable\" style=\"font-family: var(--font-primary); font-size: var(--font-size-14);\">\n<tbody>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle0\">D10 </span></td>\n<td width=\"200\"><span class=\"fontstyle0\">EFFECT</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">1 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is nauseated for 1 round</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">2 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains resistance 10 to a random energy type (acid, cold, electricity, fire, or sonic) for the next 10 minutes</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">3 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target takes 8d6 damage of a random energy type (acid, cold, electricity, fire, or sonic), or half as much on a successful save</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">4 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target regains 4d8 Hit Points</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">5 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains a climb, fly, or swim speed (determined randomly) equal to its land speed for 10 minutes</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">6 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is affected by a </span><span class=\"fontstyle3\">restoration </span><span class=\"fontstyle2\">spell</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">7 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is confused for 1d4 rounds</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">8 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains 1d4 negative levels</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">9 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is affected by </span><span class=\"fontstyle3\">baleful polymorph </span><span class=\"fontstyle2\">(level 6); its polymorphed form is random</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">10 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target&rsquo;s head is wracked with pain, dealing 18d6 damage (half on a successful save)</span></td>\n</tr>\n</tbody>\n</table>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 11,
+    "modifiers": [],
+    "price": 22500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 112",
+    "system": "hand"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/probability_tendril_mk_3.json
+++ b/src/items/equipment/probability_tendril_mk_3.json
@@ -1,0 +1,61 @@
+{
+  "_id": "8A2kSOaGLsDkyp0l",
+  "name": "Probability tendril Mk 3",
+  "type": "augmentation",
+  "data": {
+    "type": "biotech",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 50
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">One of your hands is replaced by a lab-grown protean tendril that allows you to replicate a protean&rsquo;s chaotic powers. As a standard action, you can spend 1 Resolve Point to target a creature within 30 feet and force it to succeed at a Fortitude save (DC = 10 + half your level + your Constitution modifier) or be affected by a random effect from the table below.</span></p>\n<p><span class=\"fontstyle0\">You can choose not to spend a Resolve Point before you use this ability, but doing so requires you to succeed at the same save or be subject to the same effect. The augmentation&rsquo;s </span><span class=\"fontstyle0\">model determines which die you roll on the following table to determine the random effect.</span></p>\n<p><span class=\"fontstyle2\"><strong>Mk 3:</strong> </span><span class=\"fontstyle0\">Roll 1d10 on the table</span></p>\n<table class=\"NormalTable\" style=\"font-family: var(--font-primary); font-size: var(--font-size-14);\">\n<tbody>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle0\">D10 </span></td>\n<td width=\"200\"><span class=\"fontstyle0\">EFFECT</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">1 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is nauseated for 1 round</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">2 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains resistance 10 to a random energy type (acid, cold, electricity, fire, or sonic) for the next 10 minutes</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">3 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target takes 8d6 damage of a random energy type (acid, cold, electricity, fire, or sonic), or half as much on a successful save</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">4 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target regains 4d8 Hit Points</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">5 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains a climb, fly, or swim speed (determined randomly) equal to its land speed for 10 minutes</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">6 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is affected by a </span><span class=\"fontstyle3\">restoration </span><span class=\"fontstyle2\">spell</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">7 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is confused for 1d4 rounds</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">8 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target gains 1d4 negative levels</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">9 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target is affected by </span><span class=\"fontstyle3\">baleful polymorph </span><span class=\"fontstyle2\">(level 6); its polymorphed form is random</span></td>\n</tr>\n<tr>\n<td style=\"width: 10%; text-align: center;\" width=\"200\"><span class=\"fontstyle2\">10 </span></td>\n<td width=\"200\"><span class=\"fontstyle2\">Target&rsquo;s head is wracked with pain, dealing 18d6 damage (half on a successful save)</span></td>\n</tr>\n</tbody>\n</table>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 15,
+    "modifiers": [],
+    "price": 115000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 112",
+    "system": "hand"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/proton_snare_mk_i.json
+++ b/src/items/equipment/proton_snare_mk_i.json
@@ -1,0 +1,71 @@
+{
+  "_id": "jLezsD7eYl8Bn0Ag",
+  "name": "Proton snare Mk I",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 7
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This disc-shaped device has multidirectional rollers on five points and a stiff cable with a large button on its end for activation. As a standard action, you may deploy the </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">on solid ground up to 20 feet away. As a move action, you can activate the snare by stomping on or pressing the switch. The snare emits a 20-foot cone of high-intensity muon lasers upward. Incorporeal creatures within the cone must make a Reflex save (DC = 10 + the snare&rsquo;s level) or be drawn into the trap, closing them inside, regardless of size. Trapped creatures are suspended, and don&rsquo;t need to breathe, eat, or drink. The snare emits a loud alarm for one round if a trapped creature loses its incorporeal state, and then automatically opens and releases all contained creatures randomly into the spaces around it.</span></p>\n<p><span class=\"fontstyle0\">Each version of the trap can affect only a certain CR of incorporeal creatures and trap up to a certain number of Hit Points. If multiple incorporeal creatures are in the trap cone, start with those closest to the trap when it&rsquo;s activated, trapping those creatures and deducting their current Hit Points from the Hit Point capacity until the device reaches maximum. All remaining creatures are unaffected.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">can&rsquo;t be activated again until emptied (even if it&rsquo;s not at capacity). Emptying a </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">requires a full </span><span class=\"fontstyle0\">action, and releases its contents randomly into either the spaces around it or another snare with available capacity.</span></p>\n<p><span class=\"fontstyle7\"><strong>Mk I (Level 2):</strong> </span><span class=\"fontstyle0\">Affects up to CR 3; 50 HP capacity.</span><br style=\"font-style: normal; font-variant: normal; font-weight: normal; letter-spacing: normal; line-height: normal; orphans: 2; text-align: -webkit-auto; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px;\" /><br /></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 2,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/proton_snare_mk_ii.json
+++ b/src/items/equipment/proton_snare_mk_ii.json
@@ -1,0 +1,71 @@
+{
+  "_id": "6IocknY3etHxVbzd",
+  "name": "Proton snare Mk II",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 10
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This disc-shaped device has multidirectional rollers on five points and a stiff cable with a large button on its end for activation. As a standard action, you may deploy the </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">on solid ground up to 20 feet away. As a move action, you can activate the snare by stomping on or pressing the switch. The snare emits a 20-foot cone of high-intensity muon lasers upward. Incorporeal creatures within the cone must make a Reflex save (DC = 10 + the snare&rsquo;s level) or be drawn into the trap, closing them inside, regardless of size. Trapped creatures are suspended, and don&rsquo;t need to breathe, eat, or drink. The snare emits a loud alarm for one round if a trapped creature loses its incorporeal state, and then automatically opens and releases all contained creatures randomly into the spaces around it.</span></p>\n<p><span class=\"fontstyle0\">Each version of the trap can affect only a certain CR of incorporeal creatures and trap up to a certain number of Hit Points. If multiple incorporeal creatures are in the trap cone, start with those closest to the trap when it&rsquo;s activated, trapping those creatures and deducting their current Hit Points from the Hit Point capacity until the device reaches maximum. All remaining creatures are unaffected.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">can&rsquo;t be activated again until emptied (even if it&rsquo;s not at capacity). Emptying a </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">requires a full </span><span class=\"fontstyle0\">action, and releases its contents randomly into either the spaces around it or another snare with available capacity.</span></p>\n<p><span class=\"fontstyle7\"><strong>Mk II (Level 5):</strong> </span><span class=\"fontstyle0\">Affects up to CR 7; 125 HP capacity.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 5,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 2200,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/proton_snare_mk_iii.json
+++ b/src/items/equipment/proton_snare_mk_iii.json
@@ -1,0 +1,71 @@
+{
+  "_id": "QJF0uy6DNufYOvwZ",
+  "name": "Proton snare Mk III",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 14
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This disc-shaped device has multidirectional rollers on five points and a stiff cable with a large button on its end for activation. As a standard action, you may deploy the </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">on solid ground up to 20 feet away. As a move action, you can activate the snare by stomping on or pressing the switch. The snare emits a 20-foot cone of high-intensity muon lasers upward. Incorporeal creatures within the cone must make a Reflex save (DC = 10 + the snare&rsquo;s level) or be drawn into the trap, closing them inside, regardless of size. Trapped creatures are suspended, and don&rsquo;t need to breathe, eat, or drink. The snare emits a loud alarm for one round if a trapped creature loses its incorporeal state, and then automatically opens and releases all contained creatures randomly into the spaces around it.</span></p>\n<p><span class=\"fontstyle0\">Each version of the trap can affect only a certain CR of incorporeal creatures and trap up to a certain number of Hit Points. If multiple incorporeal creatures are in the trap cone, start with those closest to the trap when it&rsquo;s activated, trapping those creatures and deducting their current Hit Points from the Hit Point capacity until the device reaches maximum. All remaining creatures are unaffected.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">can&rsquo;t be activated again until emptied (even if it&rsquo;s not at capacity). Emptying a </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">requires a full </span><span class=\"fontstyle0\">action, and releases its contents randomly into either the spaces around it or another snare with available capacity.</span></p>\n<p><span class=\"fontstyle7\"><strong>Mk III (Level 9):</strong>&nbsp;</span><span class=\"fontstyle0\">Affects up to CR 11; 200&nbsp;HP capacity.<br /></span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 9,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 8200,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/proton_snare_mk_iv.json
+++ b/src/items/equipment/proton_snare_mk_iv.json
@@ -1,0 +1,71 @@
+{
+  "_id": "8MdbInD93kMiivu0",
+  "name": "Proton snare Mk IV",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 16
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This disc-shaped device has multidirectional rollers on five points and a stiff cable with a large button on its end for activation. As a standard action, you may deploy the </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">on solid ground up to 20 feet away. As a move action, you can activate the snare by stomping on or pressing the switch. The snare emits a 20-foot cone of high-intensity muon lasers upward. Incorporeal creatures within the cone must make a Reflex save (DC = 10 + the snare&rsquo;s level) or be drawn into the trap, closing them inside, regardless of size. Trapped creatures are suspended, and don&rsquo;t need to breathe, eat, or drink. The snare emits a loud alarm for one round if a trapped creature loses its incorporeal state, and then automatically opens and releases all contained creatures randomly into the spaces around it.</span></p>\n<p><span class=\"fontstyle0\">Each version of the trap can affect only a certain CR of incorporeal creatures and trap up to a certain number of Hit Points. If multiple incorporeal creatures are in the trap cone, start with those closest to the trap when it&rsquo;s activated, trapping those creatures and deducting their current Hit Points from the Hit Point capacity until the device reaches maximum. All remaining creatures are unaffected.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">can&rsquo;t be activated again until emptied (even if it&rsquo;s not at capacity). Emptying a </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">requires a full </span><span class=\"fontstyle0\">action, and releases its contents randomly into either the spaces around it or another snare with available capacity.</span></p>\n<p><span class=\"fontstyle0\"><span class=\"fontstyle7\"><strong>Mk IV (Level 11):</strong>&nbsp;</span><span class=\"fontstyle0\">Affects up to CR 15; 300 HP capacity.</span><br /></span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 11,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 18100,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/proton_snare_mk_v.json
+++ b/src/items/equipment/proton_snare_mk_v.json
@@ -1,0 +1,71 @@
+{
+  "_id": "raSbt1n2pwsi8m7n",
+  "name": "Proton snare Mk V",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 51
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This disc-shaped device has multidirectional rollers on five points and a stiff cable with a large button on its end for activation. As a standard action, you may deploy the </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">on solid ground up to 20 feet away. As a move action, you can activate the snare by stomping on or pressing the switch. The snare emits a 20-foot cone of high-intensity muon lasers upward. Incorporeal creatures within the cone must make a Reflex save (DC = 10 + the snare&rsquo;s level) or be drawn into the trap, closing them inside, regardless of size. Trapped creatures are suspended, and don&rsquo;t need to breathe, eat, or drink. The snare emits a loud alarm for one round if a trapped creature loses its incorporeal state, and then automatically opens and releases all contained creatures randomly into the spaces around it.</span></p>\n<p><span class=\"fontstyle0\">Each version of the trap can affect only a certain CR of incorporeal creatures and trap up to a certain number of Hit Points. If multiple incorporeal creatures are in the trap cone, start with those closest to the trap when it&rsquo;s activated, trapping those creatures and deducting their current Hit Points from the Hit Point capacity until the device reaches maximum. All remaining creatures are unaffected.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">can&rsquo;t be activated again until emptied (even if it&rsquo;s not at capacity). Emptying a </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">requires a full </span><span class=\"fontstyle0\">action, and releases its contents randomly into either the spaces around it or another snare with available capacity.</span></p>\n<p><span class=\"fontstyle0\"><span class=\"fontstyle7\"><strong>Mk V (Level 16):</strong>&nbsp;</span><span class=\"fontstyle0\">Affects up to CR 20; 500 HP capacity.</span><br /></span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 16,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 141000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/proton_snare_mk_vi.json
+++ b/src/items/equipment/proton_snare_mk_vi.json
@@ -1,0 +1,71 @@
+{
+  "_id": "ZJel2Jdo0gNrmUwM",
+  "name": "Proton snare Mk VI",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 55
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This disc-shaped device has multidirectional rollers on five points and a stiff cable with a large button on its end for activation. As a standard action, you may deploy the </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">on solid ground up to 20 feet away. As a move action, you can activate the snare by stomping on or pressing the switch. The snare emits a 20-foot cone of high-intensity muon lasers upward. Incorporeal creatures within the cone must make a Reflex save (DC = 10 + the snare&rsquo;s level) or be drawn into the trap, closing them inside, regardless of size. Trapped creatures are suspended, and don&rsquo;t need to breathe, eat, or drink. The snare emits a loud alarm for one round if a trapped creature loses its incorporeal state, and then automatically opens and releases all contained creatures randomly into the spaces around it.</span></p>\n<p><span class=\"fontstyle0\">Each version of the trap can affect only a certain CR of incorporeal creatures and trap up to a certain number of Hit Points. If multiple incorporeal creatures are in the trap cone, start with those closest to the trap when it&rsquo;s activated, trapping those creatures and deducting their current Hit Points from the Hit Point capacity until the device reaches maximum. All remaining creatures are unaffected.</span></p>\n<p><span class=\"fontstyle0\">A </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">can&rsquo;t be activated again until emptied (even if it&rsquo;s not at capacity). Emptying a </span><span class=\"fontstyle2\">proton snare </span><span class=\"fontstyle0\">requires a full </span><span class=\"fontstyle0\">action, and releases its contents randomly into either the spaces around it or another snare with available capacity.</span></p>\n<p><span class=\"fontstyle0\"><span class=\"fontstyle7\"><strong>Mk VI (Level 20):</strong>&nbsp;</span><span class=\"fontstyle0\">Affects up to CR 25; unlimited HP capacity.</span><br /></span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 20,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 890000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/quantogram.json
+++ b/src/items/equipment/quantogram.json
@@ -1,0 +1,70 @@
+{
+  "_id": "78V73VcDr3kKCbb1",
+  "name": "Quantogram",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 14
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Predominantly used by criminal enterprises, the quantogram has seen more mainstream use since Drift beacon transponder relays became less reliable for communication during the Drift Crisis. Sold as a matching set of two devices, these appear as small comm unit&ndash;sized keyboards with simple liquid crystal text displays. Thanks to the entangled quantum particles contained within, typing a 25-character message into one device instantly displays that message on all other paired devices up to a system-wide distance. Messaging in this way can&rsquo;t be intercepted or traced. Multiple sets of quantograms can be linked together in a process taking 1 hour.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 1,
+    "identified": false,
+    "level": 9,
+    "modifiers": [],
+    "price": 15800,
+    "quantity": 2,
+    "quantityPerPack": 2,
+    "source": "DC pg. 54",
+    "usage": {
+      "per": "",
+      "value": null
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/quantum_tunnelling_coverall.json
+++ b/src/items/equipment/quantum_tunnelling_coverall.json
@@ -1,0 +1,70 @@
+{
+  "_id": "9YXozNKzX3wb5BPC",
+  "name": "Quantum tunnelling coverall",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "charge",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 18
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 20,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This heavy, form-fitting jumpsuit has battery nodes embedded across its surface. As a move action, you can activate the quantum tunneling coverall and become incorporeal until the end of your next turn.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 13,
+    "modifiers": [],
+    "price": 47800,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 54",
+    "usage": {
+      "per": "action",
+      "value": 4
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/ring_of_genie_calling_djinn.json
+++ b/src/items/equipment/ring_of_genie_calling_djinn.json
@@ -1,0 +1,87 @@
+{
+  "_id": "pjv85eKX8TIPBSMe",
+  "name": "Ring of Genie Calling, Djinn",
+  "type": "magic",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 14
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">In ages past, it was common for genies to punish their own by binding them to an object such as a lamp or ring, allowing that object&rsquo;s possessor to force the genie to do their bidding. Such a punishment is rarely used anymore, but the tradition has continued in other forms. Sometimes, as part of a contract or to pay off a debt, a genie will agree to a period of servitude, binding themselves to a ring or other item and presenting it to the holder of the contract.</span></p>\n<p><span class=\"fontstyle0\">Once per week, you can use the ring to beseech the ring&rsquo;s bonded genie for help in one of two ways. First, you may ask it a question, as the </span><span class=\"fontstyle2\">contact other plane </span><span class=\"fontstyle0\">spell, except the genie always gives a truthful answer if it knows the answer, and no answer if it doesn&rsquo;t. Alternatively, you can request that the genie make an object for you, as the </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">spell. After you make your request, the object appears in an adjacent square. Bonded djinn and shaitan are capable of casting </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">as a 4th-level spell in this manner, while bonded efreet and marids are capable of casting </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">as a 5th-level spell.</span></p>\n<p><span class=\"fontstyle0\">Additionally, each ring gives the wearer energy resistance, shown below.</span></p>\n<p><span class=\"fontstyle4\"><strong>Ring of Genie Calling, Djinn (Level 9):</strong> </span><span class=\"fontstyle0\">Electricity resistance 5</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 9,
+    "limitedWear": true,
+    "modifiers": [
+      {
+        "_id": "d4f252ef-4de7-47c5-aa53-25a3773a8fd3",
+        "name": "Ring of Genie Calling, Djinn",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": true,
+        "max": 5,
+        "modifier": "5",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "electricity"
+      }
+    ],
+    "price": 15900,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 54",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/equipment/finger/ring-cabochon-silver-teal.webp"
+}

--- a/src/items/equipment/ring_of_genie_calling_efreeti.json
+++ b/src/items/equipment/ring_of_genie_calling_efreeti.json
@@ -1,0 +1,87 @@
+{
+  "_id": "tWhEl8g2y1dcHSnF",
+  "name": "Ring of Genie Calling, Efreeti",
+  "type": "magic",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 50
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">In ages past, it was common for genies to punish their own by binding them to an object such as a lamp or ring, allowing that object&rsquo;s possessor to force the genie to do their bidding. Such a punishment is rarely used anymore, but the tradition has continued in other forms. Sometimes, as part of a contract or to pay off a debt, a genie will agree to a period of servitude, binding themselves to a ring or other item and presenting it to the holder of the contract.</span></p>\n<p><span class=\"fontstyle0\">Once per week, you can use the ring to beseech the ring&rsquo;s bonded genie for help in one of two ways. First, you may ask it a question, as the </span><span class=\"fontstyle2\">contact other plane </span><span class=\"fontstyle0\">spell, except the genie always gives a truthful answer if it knows the answer, and no answer if it doesn&rsquo;t. Alternatively, you can request that the genie make an object for you, as the </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">spell. After you make your request, the object appears in an adjacent square. Bonded djinn and shaitan are capable of casting </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">as a 4th-level spell in this manner, while bonded efreet and marids are capable of casting </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">as a 5th-level spell.</span></p>\n<p><span class=\"fontstyle0\">Additionally, each ring gives the wearer energy resistance, shown below.</span></p>\n<p><span class=\"fontstyle4\"><strong>Ring of Genie Calling, Efreeti (Level 15):</strong>&nbsp;</span><span class=\"fontstyle0\">Fire resistance 15</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 15,
+    "limitedWear": true,
+    "modifiers": [
+      {
+        "_id": "d4f252ef-4de7-47c5-aa53-25a3773a8fd3",
+        "name": "Ring of Genie Calling, Efreeti",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": true,
+        "max": 15,
+        "modifier": "15",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "fire"
+      }
+    ],
+    "price": 112000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 54",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/equipment/finger/ring-cabochon-squared-gold-red.webp"
+}

--- a/src/items/equipment/ring_of_genie_calling_marid.json
+++ b/src/items/equipment/ring_of_genie_calling_marid.json
@@ -1,0 +1,87 @@
+{
+  "_id": "HW2zMBCQnfSxuPb0",
+  "name": "Ring of Genie Calling, Marid",
+  "type": "magic",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 52
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">In ages past, it was common for genies to punish their own by binding them to an object such as a lamp or ring, allowing that object&rsquo;s possessor to force the genie to do their bidding. Such a punishment is rarely used anymore, but the tradition has continued in other forms. Sometimes, as part of a contract or to pay off a debt, a genie will agree to a period of servitude, binding themselves to a ring or other item and presenting it to the holder of the contract.</span></p>\n<p><span class=\"fontstyle0\">Once per week, you can use the ring to beseech the ring&rsquo;s bonded genie for help in one of two ways. First, you may ask it a question, as the </span><span class=\"fontstyle2\">contact other plane </span><span class=\"fontstyle0\">spell, except the genie always gives a truthful answer if it knows the answer, and no answer if it doesn&rsquo;t. Alternatively, you can request that the genie make an object for you, as the </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">spell. After you make your request, the object appears in an adjacent square. Bonded djinn and shaitan are capable of casting </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">as a 4th-level spell in this manner, while bonded efreet and marids are capable of casting </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">as a 5th-level spell.</span></p>\n<p><span class=\"fontstyle0\">Additionally, each ring gives the wearer energy resistance, shown below.</span></p>\n<p><span class=\"fontstyle4\"><strong>Ring of Genie Calling, Marid (Level 17):</strong>&nbsp;</span><span class=\"fontstyle0\">Cold resistance 20</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 17,
+    "limitedWear": true,
+    "modifiers": [
+      {
+        "_id": "d4f252ef-4de7-47c5-aa53-25a3773a8fd3",
+        "name": "Ring of Genie Calling, Marid",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": true,
+        "max": 20,
+        "modifier": "20",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "cold"
+      }
+    ],
+    "price": 270000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 54",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/equipment/finger/ring-cabochon-white-blue.webp"
+}

--- a/src/items/equipment/ring_of_genie_calling_shaitan.json
+++ b/src/items/equipment/ring_of_genie_calling_shaitan.json
@@ -1,0 +1,87 @@
+{
+  "_id": "rrhgDAoLW4o7URLK",
+  "name": "Ring of Genie Calling, Shaitan",
+  "type": "magic",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 17
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "capacity": {
+      "max": 0,
+      "value": 0
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">In ages past, it was common for genies to punish their own by binding them to an object such as a lamp or ring, allowing that object&rsquo;s possessor to force the genie to do their bidding. Such a punishment is rarely used anymore, but the tradition has continued in other forms. Sometimes, as part of a contract or to pay off a debt, a genie will agree to a period of servitude, binding themselves to a ring or other item and presenting it to the holder of the contract.</span></p>\n<p><span class=\"fontstyle0\">Once per week, you can use the ring to beseech the ring&rsquo;s bonded genie for help in one of two ways. First, you may ask it a question, as the </span><span class=\"fontstyle2\">contact other plane </span><span class=\"fontstyle0\">spell, except the genie always gives a truthful answer if it knows the answer, and no answer if it doesn&rsquo;t. Alternatively, you can request that the genie make an object for you, as the </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">spell. After you make your request, the object appears in an adjacent square. Bonded djinn and shaitan are capable of casting </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">as a 4th-level spell in this manner, while bonded efreet and marids are capable of casting </span><span class=\"fontstyle2\">creation </span><span class=\"fontstyle0\">as a 5th-level spell.</span></p>\n<p><span class=\"fontstyle0\">Additionally, each ring gives the wearer energy resistance, shown below.</span></p>\n<p><span class=\"fontstyle4\"><strong>Ring of Genie Calling, Shaitan (Level 12):</strong>&nbsp;</span><span class=\"fontstyle0\">Acid resistance 10</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 0,
+    "identified": false,
+    "level": 12,
+    "limitedWear": true,
+    "modifiers": [
+      {
+        "_id": "d4f252ef-4de7-47c5-aa53-25a3773a8fd3",
+        "name": "Ring of Genie Calling, Shaitan",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": true,
+        "max": 10,
+        "modifier": "10",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "acid"
+      }
+    ],
+    "price": 39000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 54",
+    "usage": {
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/equipment/finger/ring-cabochon-silver-gold-green.webp"
+}

--- a/src/items/equipment/scrambler_pistol_cockroach.json
+++ b/src/items/equipment/scrambler_pistol_cockroach.json
@@ -1,0 +1,255 @@
+{
+  "_id": "Q9THAoQoKcGqJyPe",
+  "name": "Scrambler pistol, cockroach",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 36
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 7,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Confuse",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A group of skittermander researchers on Pritinzo have found a way to fight back against the Swarm. By finely tuning the frequency of certain weapons, the engineers can temporarily disrupt telepathic communication, including the hive mind capabilities of Swarm creatures. Cut off from communication with their fellow components, Swarm creatures are disconcerted, even if just for a moment, allowing the planet&rsquo;s resistance a chance to fight back.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 7,
+    "modifiers": [],
+    "price": 5200,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": true,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 60
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "fort",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.int.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 107",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/scrambler_pistol_dragonfly.json
+++ b/src/items/equipment/scrambler_pistol_dragonfly.json
@@ -1,0 +1,255 @@
+{
+  "_id": "PxrljdRBYIKDo2oF",
+  "name": "Scrambler pistol, dragonfly",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 45
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 10,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Confuse",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "3d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A group of skittermander researchers on Pritinzo have found a way to fight back against the Swarm. By finely tuning the frequency of certain weapons, the engineers can temporarily disrupt telepathic communication, including the hive mind capabilities of Swarm creatures. Cut off from communication with their fellow components, Swarm creatures are disconcerted, even if just for a moment, allowing the planet&rsquo;s resistance a chance to fight back.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 10,
+    "modifiers": [],
+    "price": 19400,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": true,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 60
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "fort",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.int.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 107",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/scrambler_pistol_locust.json
+++ b/src/items/equipment/scrambler_pistol_locust.json
@@ -1,0 +1,255 @@
+{
+  "_id": "DhgFYkD6Da4rodYk",
+  "name": "Scrambler pistol, locust",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 54
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 13,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Confuse",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A group of skittermander researchers on Pritinzo have found a way to fight back against the Swarm. By finely tuning the frequency of certain weapons, the engineers can temporarily disrupt telepathic communication, including the hive mind capabilities of Swarm creatures. Cut off from communication with their fellow components, Swarm creatures are disconcerted, even if just for a moment, allowing the planet&rsquo;s resistance a chance to fight back.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 13,
+    "modifiers": [],
+    "price": 44700,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": true,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 60
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "fort",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.int.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 107",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/scrambler_pistol_termite.json
+++ b/src/items/equipment/scrambler_pistol_termite.json
@@ -1,0 +1,255 @@
+{
+  "_id": "xHv056ZdwScZXGhu",
+  "name": "Scrambler pistol, termite",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 21
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Confuse",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "1d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A group of skittermander researchers on Pritinzo have found a way to fight back against the Swarm. By finely tuning the frequency of certain weapons, the engineers can temporarily disrupt telepathic communication, including the hive mind capabilities of Swarm creatures. Cut off from communication with their fellow components, Swarm creatures are disconcerted, even if just for a moment, allowing the planet&rsquo;s resistance a chance to fight back.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 2,
+    "modifiers": [],
+    "price": 800,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": true,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 60
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "fort",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.int.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 107",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/scrambler_rifle_cockroach.json
+++ b/src/items/equipment/scrambler_rifle_cockroach.json
@@ -1,0 +1,255 @@
+{
+  "_id": "0Fa20fx7TYbckHev",
+  "name": "Scrambler rifle, cockroach",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 8,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Confuse",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A group of skittermander researchers on Pritinzo have found a way to fight back against the Swarm. By finely tuning the frequency of certain weapons, the engineers can temporarily disrupt telepathic communication, including the hive mind capabilities of Swarm creatures. Cut off from communication with their fellow components, Swarm creatures are disconcerted, even if just for a moment, allowing the planet&rsquo;s resistance a chance to fight back.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 8,
+    "modifiers": [],
+    "price": 9850,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": true,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 90
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "fort",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.int.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 107",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/scrambler_rifle_dragonfly.json
+++ b/src/items/equipment/scrambler_rifle_dragonfly.json
@@ -1,0 +1,255 @@
+{
+  "_id": "NdQspidvyVrOPfM0",
+  "name": "Scrambler rifle, dragonfly",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 48
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 11,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Confuse",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "3d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A group of skittermander researchers on Pritinzo have found a way to fight back against the Swarm. By finely tuning the frequency of certain weapons, the engineers can temporarily disrupt telepathic communication, including the hive mind capabilities of Swarm creatures. Cut off from communication with their fellow components, Swarm creatures are disconcerted, even if just for a moment, allowing the planet&rsquo;s resistance a chance to fight back.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 11,
+    "modifiers": [],
+    "price": 24900,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": true,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 90
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "fort",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.int.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 107",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/scrambler_rifle_locust.json
+++ b/src/items/equipment/scrambler_rifle_locust.json
@@ -1,0 +1,255 @@
+{
+  "_id": "6l1HELq68uQAISyh",
+  "name": "Scrambler rifle, locust",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 57
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 14,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Confuse",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A group of skittermander researchers on Pritinzo have found a way to fight back against the Swarm. By finely tuning the frequency of certain weapons, the engineers can temporarily disrupt telepathic communication, including the hive mind capabilities of Swarm creatures. Cut off from communication with their fellow components, Swarm creatures are disconcerted, even if just for a moment, allowing the planet&rsquo;s resistance a chance to fight back.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 14,
+    "modifiers": [],
+    "price": 82600,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": true,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 90
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "fort",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.int.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 107",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/scrambler_rifle_termite.json
+++ b/src/items/equipment/scrambler_rifle_termite.json
@@ -1,0 +1,255 @@
+{
+  "_id": "UFwB5uZl8tQjM7he",
+  "name": "Scrambler rifle, termite",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 24
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 3,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Confuse",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "1d6",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A group of skittermander researchers on Pritinzo have found a way to fight back against the Swarm. By finely tuning the frequency of certain weapons, the engineers can temporarily disrupt telepathic communication, including the hive mind capabilities of Swarm creatures. Cut off from communication with their fellow components, Swarm creatures are disconcerted, even if just for a moment, allowing the planet&rsquo;s resistance a chance to fight back.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 3,
+    "modifiers": [],
+    "price": 1520,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": true,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 90
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "fort",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.int.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 107",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/serum_of_earthen_stature.json
+++ b/src/items/equipment/serum_of_earthen_stature.json
@@ -1,0 +1,120 @@
+{
+  "_id": "pJ5sMgGCaWZEAZrW",
+  "name": "Serum of earthen stature",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "1",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This chalky, khaki-colored liquid is incredibly dense and unpalatable to most species. For 1 hour after drinking a </span><span class=\"fontstyle2\">serum of earthen stature</span><span class=\"fontstyle0\">, you can&rsquo;t be knocked prone (though you can still choose to become prone), and if an effect would move you, it moves you 10 feet fewer instead (to a minimum of 0 feet). These benefits function only when you&rsquo;re touching a solid surface with at least one limb.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 1,
+    "modifiers": [],
+    "price": 50,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/potion-bottle-corked-white.webp"
+}

--- a/src/items/equipment/serum_of_fetid_verdancy.json
+++ b/src/items/equipment/serum_of_fetid_verdancy.json
@@ -1,0 +1,120 @@
+{
+  "_id": "bxjU33Re6fl2a4mo",
+  "name": "Serum of fetid verdancy",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This serum looks and smells like a puree of rancid vegetables left in the sun for a few days. While incredibly hard to choke down, imbibing the serum causes you to sprout several stalks of starchy green florets that grow all over your body into clumps resembling jawless skulls, shrieking faces, open claws, or other unnerving images. The florets also emit a choking gas that smells putrid and foul. For 1 minute, you gain fast healing 5; for the duration, each creature within 10 feet of you must succeed at a Fortitude save (DC = 15 + half your character level) or become sickened for 1 round. A creature that succeeds at this save is immune to the stench from this serum&rsquo;s effects for 24 hours. This macabre plant growth is edible, but it tastes terrible and provides no nutritional value.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 10,
+    "modifiers": [],
+    "price": 2400,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/bottle-conical-corked-green.webp"
+}

--- a/src/items/equipment/serum_of_fey’s_fickle_fancy_mk_1.json
+++ b/src/items/equipment/serum_of_fey’s_fickle_fancy_mk_1.json
@@ -1,0 +1,120 @@
+{
+  "_id": "WvWK9rHLh8yKlVFn",
+  "name": "Serum of fey’s fickle fancy, mk 1",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p>A serum of fey&rsquo;s fickle fancy is a vial of viscous liquid whose colors shift and changes constantly. Upon consuming this serum, roll a d6 a number of times equal to the mark of the serum (rerolling any duplicate results) and apply the effects listed in the table below.</p>\n<table style=\"width: 100%; height: 136px;\">\n<tbody>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">D6</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">EFFECT</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">1</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">Sparkling clouds fill your vision, and you're dazzled for 1 minute</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">2</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You can speak only in singsong rhyme for 1 minute.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">3</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You change colors constantly for 1 minute.</td>\n</tr>\n<tr style=\"height: 34px;\">\n<td style=\"width: 10%; height: 34px; text-align: center;\" width=\"200\">4</td>\n<td style=\"width: 92.7007%; height: 34px;\" width=\"200\">You regain 4d8 Hit Points. If this amount exceeds that needed to reach your maximum Hit Points, you also become nauseated for 1 round.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">5</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You gain a +1 luck bonus to AC for 1 minute.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">6</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You gain a +2 luck bonus on the first d20 roll you make within the next 1 minute.</td>\n</tr>\n</tbody>\n</table>\n<p><br /><br /></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 3,
+    "modifiers": [],
+    "price": 250,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/conical-ornate-purple.webp"
+}

--- a/src/items/equipment/serum_of_fey’s_fickle_fancy_mk_2.json
+++ b/src/items/equipment/serum_of_fey’s_fickle_fancy_mk_2.json
@@ -1,0 +1,120 @@
+{
+  "_id": "kN17n32XvK3DX9zd",
+  "name": "Serum of fey’s fickle fancy, mk 2",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p>A serum of fey&rsquo;s fickle fancy is a vial of viscous liquid whose colors shift and changes constantly. Upon consuming this serum, roll a d6 a number of times equal to the mark of the serum (rerolling any duplicate results) and apply the effects listed in the table below.</p>\n<table style=\"width: 100%; height: 136px;\">\n<tbody>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">D6</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">EFFECT</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">1</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">Sparkling clouds fill your vision, and you're dazzled for 1 minute</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">2</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You can speak only in singsong rhyme for 1 minute.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">3</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You change colors constantly for 1 minute.</td>\n</tr>\n<tr style=\"height: 34px;\">\n<td style=\"width: 10%; height: 34px; text-align: center;\" width=\"200\">4</td>\n<td style=\"width: 92.7007%; height: 34px;\" width=\"200\">You regain 4d8 Hit Points. If this amount exceeds that needed to reach your maximum Hit Points, you also become nauseated for 1 round.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">5</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You gain a +1 luck bonus to AC for 1 minute.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">6</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You gain a +2 luck bonus on the first d20 roll you make within the next 1 minute.</td>\n</tr>\n</tbody>\n</table>\n<p><br /><br /></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 7,
+    "modifiers": [],
+    "price": 950,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/conical-ornate-purple.webp"
+}

--- a/src/items/equipment/serum_of_fey’s_fickle_fancy_mk_3.json
+++ b/src/items/equipment/serum_of_fey’s_fickle_fancy_mk_3.json
@@ -1,0 +1,120 @@
+{
+  "_id": "0BLMSOSVxakbNRCN",
+  "name": "Serum of fey’s fickle fancy, mk 3",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p>A serum of fey&rsquo;s fickle fancy is a vial of viscous liquid whose colors shift and changes constantly. Upon consuming this serum, roll a d6 a number of times equal to the mark of the serum (rerolling any duplicate results) and apply the effects listed in the table below.</p>\n<table style=\"width: 100%; height: 136px;\">\n<tbody>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">D6</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">EFFECT</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">1</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">Sparkling clouds fill your vision, and you're dazzled for 1 minute</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">2</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You can speak only in singsong rhyme for 1 minute.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">3</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You change colors constantly for 1 minute.</td>\n</tr>\n<tr style=\"height: 34px;\">\n<td style=\"width: 10%; height: 34px; text-align: center;\" width=\"200\">4</td>\n<td style=\"width: 92.7007%; height: 34px;\" width=\"200\">You regain 4d8 Hit Points. If this amount exceeds that needed to reach your maximum Hit Points, you also become nauseated for 1 round.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">5</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You gain a +1 luck bonus to AC for 1 minute.</td>\n</tr>\n<tr style=\"height: 17px;\">\n<td style=\"width: 10%; height: 17px; text-align: center;\" width=\"200\">6</td>\n<td style=\"width: 92.7007%; height: 17px;\" width=\"200\">You gain a +2 luck bonus on the first d20 roll you make within the next 1 minute.</td>\n</tr>\n</tbody>\n</table>\n<p><br /><br /></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 12,
+    "modifiers": [],
+    "price": 1500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/conical-ornate-purple.webp"
+}

--- a/src/items/equipment/serum_of_fiery_vengeance.json
+++ b/src/items/equipment/serum_of_fiery_vengeance.json
@@ -1,0 +1,120 @@
+{
+  "_id": "5Dtdej0BmPAJ9dpw",
+  "name": "Serum of fiery vengeance",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This serum contains distilled energies from the Plane of Fire. It glows a dim red and emits a constant heat, regardless of ambient temperature. When you drink this serum, your body becomes covered in illusory flames. For 1 minute, any creature that hits you with a melee attack must succeed at a DC 15 Reflex saving throw or take 5 fire damage. If a creature rolls a natural 1 on this saving throw, it also gains the burning condition for 5 damage.</span> </p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 2,
+    "modifiers": [],
+    "price": 100,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/flask-corked-yellow-glow.webp"
+}

--- a/src/items/equipment/serum_of_infinite_air.json
+++ b/src/items/equipment/serum_of_infinite_air.json
@@ -1,0 +1,120 @@
+{
+  "_id": "qmTyJs4QGFwRNMtK",
+  "name": "Serum of infinite air",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This bottled quintessence from the Plane of Air is nearly invisible and adds virtually no weight to its container. For 1 hour after drinking a </span><span class=\"fontstyle2\">serum of infinite air</span><span class=\"fontstyle0\">, you don&rsquo;t need to breathe and are immune to inhaled poisons. This doesn&rsquo;t protect you from other effects of being in a vacuum or decompression.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 2,
+    "modifiers": [],
+    "price": 80,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/vial-cork-empty.webp"
+}

--- a/src/items/equipment/serum_of_long_shadows.json
+++ b/src/items/equipment/serum_of_long_shadows.json
@@ -1,0 +1,120 @@
+{
+  "_id": "CdjhGdGCiGdR0G5g",
+  "name": "Serum of long shadows",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A vial of liquid so dark that it seems to absorb nearby light, a </span><span class=\"fontstyle2\">serum of long shadows </span><span class=\"fontstyle0\">lacks any taste and is always the exact temperature of its imbiber. For 10 minutes after you drink a </span><span class=\"fontstyle2\">serum of long shadows</span><span class=\"fontstyle0\">, the light within 5 feet of you (including your space) becomes dim light, and only magical sources of light can increase the light level in this area. This effect moves with you. In addition, you take half damage from attacks and effects with the shadow descriptor.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 14,
+    "modifiers": [],
+    "price": 10000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/bottle-bulb-empty-glass.webp"
+}

--- a/src/items/equipment/serum_of_shapelessness.json
+++ b/src/items/equipment/serum_of_shapelessness.json
@@ -1,0 +1,120 @@
+{
+  "_id": "RNOTQPJYCscTQFmK",
+  "name": "Serum of shapelessness",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This liquid in this vial constantly roils within, ever shifting in viscosity and color. Imbibing this serum transforms you into a color-changing, shapeless mist, granting you the @Compendium[sfrpg.universal-creature-rules.bYTEFowbTpIeusXE]{Incorporeal} universal creature rule until the end of your next turn. If a creature that&rsquo;s incorporeal as a result of drinking the </span><span class=\"fontstyle2\">serum of the shapeless </span><span class=\"fontstyle0\">ends its turn adjacent to another creature that&rsquo;s incorporeal for the same reason, each creature adds the applicable ability modifier of the creature it shares a space with when attempting its check or roll. Only two incorporeal creatures can benefit from this effect at a time.</span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 18,
+    "modifiers": [],
+    "price": 6000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/potion-bottle-fumes-blue.webp"
+}

--- a/src/items/equipment/serum_of_water’s_protection_mk_1.json
+++ b/src/items/equipment/serum_of_water’s_protection_mk_1.json
@@ -1,0 +1,151 @@
+{
+  "_id": "0dCg3TTQniDqFGPm",
+  "name": "Serum of water’s protection, mk 1",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A&nbsp;</span><span class=\"fontstyle2\">serum of water&rsquo;s protection&nbsp;</span><span class=\"fontstyle0\">looks like a standard bottle of drinking water, but consuming it covers you with a thin layer of magically animated water. This has two effects, both of which last 1 hour. First, you gain resistance against acid and fire damage; a&nbsp;</span><span class=\"fontstyle2\">mk 1 serum of water&rsquo;s protection&nbsp;</span><span class=\"fontstyle0\">grants acid and fire resistance 5, a mk 2 serum grants acid and fire resistance 10, and a mk 3 serum grants acid and fire resistance 15. Second, you become vulnerable to cold damage, taking 50% more damage from cold effects.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>Toggle on/off the resistances in the Modifiers tab. Vulnerability to cold must be enabled in the Attributes tab of your Character Sheet.<br /></em></span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 4,
+    "modifiers": [
+      {
+        "_id": "34b31f65-821b-4e06-ad81-4a6c0380b021",
+        "name": "Serum of water’s protection, mk 1",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 5,
+        "modifier": "5",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "acid"
+      },
+      {
+        "_id": "1100d107-5913-4fee-8b45-2af432367b7d",
+        "name": "Serum of water’s protection, mk 1",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 5,
+        "modifier": "5",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "fire"
+      }
+    ],
+    "price": 350,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/bottle-round-corked-blue.webp"
+}

--- a/src/items/equipment/serum_of_water’s_protection_mk_2.json
+++ b/src/items/equipment/serum_of_water’s_protection_mk_2.json
@@ -1,0 +1,151 @@
+{
+  "_id": "TKVBJyV64g45YMzW",
+  "name": "Serum of water’s protection, mk 2",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A&nbsp;</span><span class=\"fontstyle2\">serum of water&rsquo;s protection&nbsp;</span><span class=\"fontstyle0\">looks like a standard bottle of drinking water, but consuming it covers you with a thin layer of magically animated water. This has two effects, both of which last 1 hour. First, you gain resistance against acid and fire damage; a&nbsp;</span><span class=\"fontstyle2\">mk 1 serum of water&rsquo;s protection&nbsp;</span><span class=\"fontstyle0\">grants acid and fire resistance 5, a mk 2 serum grants acid and fire resistance 10, and a mk 3 serum grants acid and fire resistance 15. Second, you become vulnerable to cold damage, taking 50% more damage from cold effects.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>Toggle on/off the resistances in the Modifiers tab. Vulnerability to cold must be enabled in the Attributes tab of your Character Sheet.<br /></em></span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 8,
+    "modifiers": [
+      {
+        "_id": "34b31f65-821b-4e06-ad81-4a6c0380b021",
+        "name": "Serum of water’s protection, mk 1",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 10,
+        "modifier": "10",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "acid"
+      },
+      {
+        "_id": "1100d107-5913-4fee-8b45-2af432367b7d",
+        "name": "Serum of water’s protection, mk 1",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 10,
+        "modifier": "10",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "fire"
+      }
+    ],
+    "price": 1500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/bottle-round-corked-blue.webp"
+}

--- a/src/items/equipment/serum_of_water’s_protection_mk_3.json
+++ b/src/items/equipment/serum_of_water’s_protection_mk_3.json
@@ -1,0 +1,151 @@
+{
+  "_id": "sOGLXrRhwTMFacU5",
+  "name": "Serum of water’s protection, mk 3",
+  "type": "consumable",
+  "data": {
+    "type": "",
+    "ability": null,
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "",
+    "actionType": "",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": "2"
+      },
+      "hp": {
+        "max": "6",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "chatFlavor": "",
+    "consumableType": "serum",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": 1,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "spell"
+          ],
+          "affectsEncumbrance": false,
+          "amount": 0,
+          "subtype": "spellSlot",
+          "weightProperty": "bulk"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A&nbsp;</span><span class=\"fontstyle2\">serum of water&rsquo;s protection&nbsp;</span><span class=\"fontstyle0\">looks like a standard bottle of drinking water, but consuming it covers you with a thin layer of magically animated water. This has two effects, both of which last 1 hour. First, you gain resistance against acid and fire damage; a&nbsp;</span><span class=\"fontstyle2\">mk 1 serum of water&rsquo;s protection&nbsp;</span><span class=\"fontstyle0\">grants acid and fire resistance 5, a mk 2 serum grants acid and fire resistance 10, and a mk 3 serum grants acid and fire resistance 15. Second, you become vulnerable to cold damage, taking 50% more damage from cold effects.</span></p>\n<p><span class=\"fontstyle0\"><br /><em>Toggle on/off the resistances in the Modifiers tab. Vulnerability to cold must be enabled in the Attributes tab of your Character Sheet.<br /></em></span></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": false,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 12,
+    "modifiers": [
+      {
+        "_id": "34b31f65-821b-4e06-ad81-4a6c0380b021",
+        "name": "Serum of water’s protection, mk 1",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 15,
+        "modifier": "15",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "acid"
+      },
+      {
+        "_id": "1100d107-5913-4fee-8b45-2af432367b7d",
+        "name": "Serum of water’s protection, mk 1",
+        "type": "untyped",
+        "condition": "",
+        "effectType": "energy-resistance",
+        "enabled": false,
+        "max": 15,
+        "modifier": "15",
+        "modifierType": "constant",
+        "notes": "",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "fire"
+      }
+    ],
+    "price": 5500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": null,
+      "descriptor": ""
+    },
+    "source": "DC pg. 113",
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": 0,
+      "per": "",
+      "value": 0
+    }
+  },
+  "img": "icons/consumables/potions/bottle-round-corked-blue.webp"
+}

--- a/src/items/equipment/shuffling_feet_mk_1.json
+++ b/src/items/equipment/shuffling_feet_mk_1.json
@@ -1,0 +1,77 @@
+{
+  "_id": "lbS3PwnzuJ2OrekE",
+  "name": "Shuffling feet Mk 1",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">By replacing your feet with those of a zombie or other slow-moving undead creature, you can move at a deliberate and unpredictable pace that confuses combatants and dampens your footfalls to a lulling susurrus. You can activate shuffling </span><span class=\"fontstyle0\">feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn. This bonus equals the necrograft&rsquo;s mark.</span></p>\n<p><span class=\"fontstyle0\">Alternatively, you can activate shuffling feet when you take a guarded step to increase the distance you move. You can move 10 feet with a guarded step with mk 1 or mk 2 shuffling feet, 15 feet with mk 3 shuffling feet, 20 feet with mk 4 shuffling feet, or up to your speed with mk 5 shuffling feet.</span></p>\n<p><span class=\"fontstyle0\">After you activate either use of your shuffling feet, you cannot activate them again until you rest for 10 minutes to recover Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 1,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Shuffling feet",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 1,
+        "modifier": "1",
+        "modifierType": "formula",
+        "notes": "You can activate shuffling feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 200,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "allFeet"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/shuffling_feet_mk_2.json
+++ b/src/items/equipment/shuffling_feet_mk_2.json
@@ -1,0 +1,77 @@
+{
+  "_id": "e725mrWszVcQRlnh",
+  "name": "Shuffling feet Mk 2",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 11
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">By replacing your feet with those of a zombie or other slow-moving undead creature, you can move at a deliberate and unpredictable pace that confuses combatants and dampens your footfalls to a lulling susurrus. You can activate shuffling </span><span class=\"fontstyle0\">feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn. This bonus equals the necrograft&rsquo;s mark.</span></p>\n<p><span class=\"fontstyle0\">Alternatively, you can activate shuffling feet when you take a guarded step to increase the distance you move. You can move 10 feet with a guarded step with mk 1 or mk 2 shuffling feet, 15 feet with mk 3 shuffling feet, 20 feet with mk 4 shuffling feet, or up to your speed with mk 5 shuffling feet.</span></p>\n<p><span class=\"fontstyle0\">After you activate either use of your shuffling feet, you cannot activate them again until you rest for 10 minutes to recover Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 6,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Shuffling feet",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 2,
+        "modifier": "2",
+        "modifierType": "formula",
+        "notes": "You can activate shuffling feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 4000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "allFeet"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/shuffling_feet_mk_3.json
+++ b/src/items/equipment/shuffling_feet_mk_3.json
@@ -1,0 +1,77 @@
+{
+  "_id": "cCrdM0RNoPmnQGiN",
+  "name": "Shuffling feet Mk 3",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 17
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">By replacing your feet with those of a zombie or other slow-moving undead creature, you can move at a deliberate and unpredictable pace that confuses combatants and dampens your footfalls to a lulling susurrus. You can activate shuffling </span><span class=\"fontstyle0\">feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn. This bonus equals the necrograft&rsquo;s mark.</span></p>\n<p><span class=\"fontstyle0\">Alternatively, you can activate shuffling feet when you take a guarded step to increase the distance you move. You can move 10 feet with a guarded step with mk 1 or mk 2 shuffling feet, 15 feet with mk 3 shuffling feet, 20 feet with mk 4 shuffling feet, or up to your speed with mk 5 shuffling feet.</span></p>\n<p><span class=\"fontstyle0\">After you activate either use of your shuffling feet, you cannot activate them again until you rest for 10 minutes to recover Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 12,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Shuffling feet",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 3,
+        "modifier": "3",
+        "modifierType": "formula",
+        "notes": "You can activate shuffling feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 30000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "allFeet"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/shuffling_feet_mk_4.json
+++ b/src/items/equipment/shuffling_feet_mk_4.json
@@ -1,0 +1,77 @@
+{
+  "_id": "3GLaa4sLKO0qwkVM",
+  "name": "Shuffling feet Mk 4",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 53
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">By replacing your feet with those of a zombie or other slow-moving undead creature, you can move at a deliberate and unpredictable pace that confuses combatants and dampens your footfalls to a lulling susurrus. You can activate shuffling </span><span class=\"fontstyle0\">feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn. This bonus equals the necrograft&rsquo;s mark.</span></p>\n<p><span class=\"fontstyle0\">Alternatively, you can activate shuffling feet when you take a guarded step to increase the distance you move. You can move 10 feet with a guarded step with mk 1 or mk 2 shuffling feet, 15 feet with mk 3 shuffling feet, 20 feet with mk 4 shuffling feet, or up to your speed with mk 5 shuffling feet.</span></p>\n<p><span class=\"fontstyle0\">After you activate either use of your shuffling feet, you cannot activate them again until you rest for 10 minutes to recover Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 18,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Shuffling feet",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "You can activate shuffling feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 350000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "allFeet"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/shuffling_feet_mk_5.json
+++ b/src/items/equipment/shuffling_feet_mk_5.json
@@ -1,0 +1,77 @@
+{
+  "_id": "hLV8tS8W46lxJOwp",
+  "name": "Shuffling feet Mk 5",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 55
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">By replacing your feet with those of a zombie or other slow-moving undead creature, you can move at a deliberate and unpredictable pace that confuses combatants and dampens your footfalls to a lulling susurrus. You can activate shuffling </span><span class=\"fontstyle0\">feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn. This bonus equals the necrograft&rsquo;s mark.</span></p>\n<p><span class=\"fontstyle0\">Alternatively, you can activate shuffling feet when you take a guarded step to increase the distance you move. You can move 10 feet with a guarded step with mk 1 or mk 2 shuffling feet, 15 feet with mk 3 shuffling feet, 20 feet with mk 4 shuffling feet, or up to your speed with mk 5 shuffling feet.</span></p>\n<p><span class=\"fontstyle0\">After you activate either use of your shuffling feet, you cannot activate them again until you rest for 10 minutes to recover Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 20,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Shuffling feet",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 5,
+        "modifier": "5",
+        "modifierType": "formula",
+        "notes": "You can activate shuffling feet when you move while hiding to gain a circumstance bonus to your Stealth checks to remain hidden until the end of your turn.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 775000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "allFeet"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/singing_star_adept.json
+++ b/src/items/equipment/singing_star_adept.json
@@ -1,0 +1,255 @@
+{
+  "_id": "SgwROeshGNpMDgwA",
+  "name": "Singing star, adept",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 36
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 7,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Knockdown",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "3d4 + @abilities.str.mod",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">An ancient and traditional pahtra weapon, the singing star consists of a long chain or rope with each end attached to a fist-sized metal slug covered in complex ridges and spikes. The wielder swings the chain, either tangling targets or using the metal sphere like a long flail, while the ridges cause the weapon to make an eerie and discomfiting whistle. Traditional versions are made from materials taken from the greatest of Vesk-6&rsquo;s predators, while more modern versions are typically made of polyceramic or carbonsteel.</span> </p>\n<p><strong>Profession (Musician)<sup>AR</sup></strong></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 7,
+    "modifiers": [],
+    "price": 7900,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": true,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": true,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": true,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": true,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 63",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "advancedM"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/singing_star_apprentice.json
+++ b/src/items/equipment/singing_star_apprentice.json
@@ -1,0 +1,255 @@
+{
+  "_id": "knW1E9p8ulI1xQNp",
+  "name": "Singing star, apprentice",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 21
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Knockdown",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "1d4 + @abilities.str.mod",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">An ancient and traditional pahtra weapon, the singing star consists of a long chain or rope with each end attached to a fist-sized metal slug covered in complex ridges and spikes. The wielder swings the chain, either tangling targets or using the metal sphere like a long flail, while the ridges cause the weapon to make an eerie and discomfiting whistle. Traditional versions are made from materials taken from the greatest of Vesk-6&rsquo;s predators, while more modern versions are typically made of polyceramic or carbonsteel.</span> </p>\n<p><strong>Profession (Musician)<sup>AR</sup></strong></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 2,
+    "modifiers": [],
+    "price": 850,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": true,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": true,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": true,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": true,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 63",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "advancedM"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/singing_star_master.json
+++ b/src/items/equipment/singing_star_master.json
@@ -1,0 +1,255 @@
+{
+  "_id": "dGacsXrVXQ0oeAsO",
+  "name": "Singing star, master",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 51
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 12,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Knockdown",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "6d4 + @abilities.str.mod",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">An ancient and traditional pahtra weapon, the singing star consists of a long chain or rope with each end attached to a fist-sized metal slug covered in complex ridges and spikes. The wielder swings the chain, either tangling targets or using the metal sphere like a long flail, while the ridges cause the weapon to make an eerie and discomfiting whistle. Traditional versions are made from materials taken from the greatest of Vesk-6&rsquo;s predators, while more modern versions are typically made of polyceramic or carbonsteel.</span> </p>\n<p><strong>Profession (Musician)<sup>AR</sup></strong></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 12,
+    "modifiers": [],
+    "price": 36400,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": true,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": true,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": true,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": true,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 63",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "advancedM"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/singing_star_sage.json
+++ b/src/items/equipment/singing_star_sage.json
@@ -1,0 +1,255 @@
+{
+  "_id": "dSJ8VETU4UzjCLTl",
+  "name": "Singing star, sage",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "mwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 96
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 17,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Knockdown",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "8d6 + @abilities.str.mod",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">An ancient and traditional pahtra weapon, the singing star consists of a long chain or rope with each end attached to a fist-sized metal slug covered in complex ridges and spikes. The wielder swings the chain, either tangling targets or using the metal sphere like a long flail, while the ridges cause the weapon to make an eerie and discomfiting whistle. Traditional versions are made from materials taken from the greatest of Vesk-6&rsquo;s predators, while more modern versions are typically made of polyceramic or carbonsteel.</span> </p>\n<p><strong>Profession (Musician)<sup>AR</sup></strong></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 17,
+    "modifiers": [],
+    "price": 245000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": true,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": true,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": true,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": true,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "none",
+      "value": null
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 63",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "advancedM"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/snapshot_sphere.json
+++ b/src/items/equipment/snapshot_sphere.json
@@ -1,0 +1,86 @@
+{
+  "_id": "ZwcxZNhzxHpQQFPR",
+  "name": "Snapshot sphere",
+  "type": "technological",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "charge",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 7
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 20,
+      "value": null
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Activated by clicking an inset button and tossing the sphere up to 30 feet, a snapshot sphere performs an instantaneous, 30-foot radius, 360-degree scan of its surroundings a second later. This image is uploaded to a designated comm unit as well as to a set of glasses included with the sphere (both of which must be within 30 feet of the sphere to receive the signal). While wearing the glasses, a creature gains telemetric insights that grant a +1 circumstance bonus to Perception checks and reduce the wearer&rsquo;s miss chance due to concealment by 5% for any creatures or features in the area. The telemetry&rsquo;s relevance fades quickly, and these benefits cease at the end of your next turn. A snapshot sphere is carefully weighted to not roll far on a level surface, and it doubles its hardness when resisting falling damage.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "hands": 1,
+    "identified": false,
+    "level": 2,
+    "modifiers": [
+      {
+        "_id": "d58720a3-386c-48a0-8630-7bd3a78d695b",
+        "name": "Snapshot sphere",
+        "type": "circumstance",
+        "condition": "",
+        "effectType": "skill",
+        "enabled": false,
+        "max": 1,
+        "modifier": "1",
+        "modifierType": "formula",
+        "notes": "While wearing the glasses connected to the Snapshot sphere within 30 ft., a creature gains telemetric insights that grant a +1 circumstance bonus to Perception checks.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "per"
+      }
+    ],
+    "price": 825,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 79",
+    "usage": {
+      "per": "action",
+      "value": 5
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/stasis_gland.json
+++ b/src/items/equipment/stasis_gland.json
@@ -1,0 +1,61 @@
+{
+  "_id": "JkBDp8ulYLX8dxzL",
+  "name": "Stasis gland",
+  "type": "augmentation",
+  "data": {
+    "type": "biotech",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 14
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Fearing the Drift might strand them deep in the void, some space travelers have popularized augmentations focused on survival. Drawing from the DNA of tardigrades and other creatures capable of surviving periods of time in inhospitable conditions, this augmentation lets you take a full action to enter a state of suspended animation in which you don&rsquo;t have to eat or breathe. While you&rsquo;re in this state, you&rsquo;re effectively unconscious. When you enter stasis, you can choose how long you want to remain in stasis or that you want to remain in stasis until specific conditions are met, such as the presence of food or breathable air. Stasis ends if you take damage.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 9,
+    "modifiers": [],
+    "price": 12500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 112",
+    "system": "spinal"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_blaster_advanced.json
+++ b/src/items/equipment/thasphalt_blaster_advanced.json
@@ -1,0 +1,255 @@
+{
+  "_id": "DwuhriG6G3bTPqCW",
+  "name": "Thasphalt blaster, advanced",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 45
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 40,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 10,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "3d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>The thasphalt blaster&rsquo;s small canister reactor attaches to a belt, arm strap, or similar configuration.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">The thasphalt blaster&rsquo;s small canister reactor attaches to a belt, arm strap, or similar configuration.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 10,
+    "modifiers": [],
+    "price": 17300,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 40
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 4
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_blaster_elite.json
+++ b/src/items/equipment/thasphalt_blaster_elite.json
@@ -1,0 +1,255 @@
+{
+  "_id": "HQqeI4tV0yubLTGE",
+  "name": "Thasphalt blaster, elite",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 57
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 40,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 14,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>The thasphalt blaster&rsquo;s small canister reactor attaches to a belt, arm strap, or similar configuration.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">The thasphalt blaster&rsquo;s small canister reactor attaches to a belt, arm strap, or similar configuration.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 14,
+    "modifiers": [],
+    "price": 69000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 50
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 4
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_blaster_light.json
+++ b/src/items/equipment/thasphalt_blaster_light.json
@@ -1,0 +1,255 @@
+{
+  "_id": "bZkJXkspDBHzWDJi",
+  "name": "Thasphalt blaster, light",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 18
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 40,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 1,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "1d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>The thasphalt blaster&rsquo;s small canister reactor attaches to a belt, arm strap, or similar configuration.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">The thasphalt blaster&rsquo;s small canister reactor attaches to a belt, arm strap, or similar configuration.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 1,
+    "modifiers": [],
+    "price": 350,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_blaster_tactical.json
+++ b/src/items/equipment/thasphalt_blaster_tactical.json
@@ -1,0 +1,255 @@
+{
+  "_id": "hJU6YqSihwwDlq6X",
+  "name": "Thasphalt blaster, tactical",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 33
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 40,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 6,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>The thasphalt blaster&rsquo;s small canister reactor attaches to a belt, arm strap, or similar configuration.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">The thasphalt blaster&rsquo;s small canister reactor attaches to a belt, arm strap, or similar configuration.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 6,
+    "modifiers": [],
+    "price": 4200,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 30
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_canister.json
+++ b/src/items/equipment/thasphalt_canister.json
@@ -1,0 +1,75 @@
+{
+  "_id": "tgSMcw1zZWAm0SxB",
+  "name": "Thasphalt canister",
+  "type": "ammunition",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "thasphalt",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p>While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>\n<p><strong>Capacity:</strong>&nbsp;20</p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 1,
+    "price": 75,
+    "quantity": 20,
+    "quantityPerPack": 20,
+    "source": "DC pg. 51",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "useCapacity": false
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/nanite-canisters.webp"
+}

--- a/src/items/equipment/thasphalt_carronade.json
+++ b/src/items/equipment/thasphalt_carronade.json
@@ -1,0 +1,255 @@
+{
+  "_id": "6Lx4xEz5RF8TafbO",
+  "name": "Thasphalt carronade",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 10
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 99
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "3",
+    "capacity": {
+      "max": 100,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 18,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Knockdown",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "8d12",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>This heavy, cannon-like device differs from most thasphalt weaponry. Instead of firing force energy created from the electromagnetic reaction, it starts the reaction and then launches the reacting thasphalt directly. An abundance of reinforcement and safety devices results in a particularly bulky, if devastating, weapon.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This heavy, cannon-like device differs from most thasphalt weaponry. Instead of firing force energy created from the electromagnetic reaction, it starts the reaction and then launches the reacting thasphalt directly. An abundance of reinforcement and safety devices results in a particularly bulky, if devastating, weapon.</span></p>\n<hr />\n<p><strong>Thasteron Weapons:</strong> While Sanjaval Spaceflight mostly abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 18,
+    "modifiers": [],
+    "price": 37500,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": true,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 80
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 50",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 50
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "heavy"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_deck_sweeper.json
+++ b/src/items/equipment/thasphalt_deck_sweeper.json
@@ -1,0 +1,255 @@
+{
+  "_id": "KS0hoNI7THk4L3fY",
+  "name": "Thasphalt deck sweeper",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 57
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 100,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 14,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Push (5 ft.)",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d12",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>A crank mechanism spins the barrels of the thasphalt deck sweeper to allow continuous sustained fire from a heavy reactor pack.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A crank mechanism spins the barrels of the thasphalt deck sweeper to allow continuous sustained fire from a heavy reactor pack.</span></p>\n<hr />\n<p><strong>Thasteron Weapons:</strong> While Sanjaval Spaceflight mostly abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 14,
+    "modifiers": [],
+    "price": 81000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": true,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 50
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 2
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "heavy"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_grenade_i.json
+++ b/src/items/equipment/thasphalt_grenade_i.json
@@ -1,0 +1,265 @@
+{
+  "_id": "U73XBaXd6LBRol2c",
+  "name": "Thasphalt grenade I",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 15
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 18
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 1,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "1d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 1,
+    "modifiers": [],
+    "price": 110,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "half"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 0,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/incendiary-grenade.webp"
+}

--- a/src/items/equipment/thasphalt_grenade_ii.json
+++ b/src/items/equipment/thasphalt_grenade_ii.json
@@ -1,0 +1,265 @@
+{
+  "_id": "2GFYrlSMpSAvrYUf",
+  "name": "Thasphalt grenade II",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 15
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 30
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 5,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 5,
+    "modifiers": [],
+    "price": 820,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "half"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/incendiary-grenade.webp"
+}

--- a/src/items/equipment/thasphalt_grenade_iii.json
+++ b/src/items/equipment/thasphalt_grenade_iii.json
@@ -1,0 +1,265 @@
+{
+  "_id": "YQl40mFOOb3QD0zO",
+  "name": "Thasphalt grenade III",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 15
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 42
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 9,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 9,
+    "modifiers": [],
+    "price": 4200,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "half"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/incendiary-grenade.webp"
+}

--- a/src/items/equipment/thasphalt_grenade_iv.json
+++ b/src/items/equipment/thasphalt_grenade_iv.json
@@ -1,0 +1,265 @@
+{
+  "_id": "IdWwcNyDEI7C0JeZ",
+  "name": "Thasphalt grenade IV",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 15
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 48
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 11,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "6d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 11,
+    "modifiers": [],
+    "price": 8250,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "half"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/incendiary-grenade.webp"
+}

--- a/src/items/equipment/thasphalt_grenade_v.json
+++ b/src/items/equipment/thasphalt_grenade_v.json
@@ -1,0 +1,265 @@
+{
+  "_id": "12gvUGsqFGD9Xrbu",
+  "name": "Thasphalt grenade V",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 15
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 90
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 15,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "10d8",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Invented by accident when an engineer didn&rsquo;t open a steam valve on a reactor, the thasphalt grenade&rsquo;s invention coincided with new emergency pressure release valves being introduced onto other thasphalt products.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 15,
+    "modifiers": [],
+    "price": 37000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "half"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/incendiary-grenade.webp"
+}

--- a/src/items/equipment/thasphalt_rifle_advanced.json
+++ b/src/items/equipment/thasphalt_rifle_advanced.json
@@ -1,0 +1,255 @@
+{
+  "_id": "Z7V2udNS13YV7zGx",
+  "name": "Thasphalt rifle, advanced",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": null
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 51
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 80,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 12,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Push (10 ft.)",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "3d10",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>A briefcase-sized reactor tethers the two-handed thasphalt rifle. The reactor can be worn slung across your body or bound to a backpack.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A briefcase-sized reactor tethers the two-handed thasphalt rifle. The reactor can be worn slung across your body or bound to a backpack.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 12,
+    "modifiers": [],
+    "price": 35100,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 80
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 8
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_rifle_elite.json
+++ b/src/items/equipment/thasphalt_rifle_elite.json
@@ -1,0 +1,255 @@
+{
+  "_id": "DYaUWrLZMUGi3efP",
+  "name": "Thasphalt rifle, elite",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": null
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 93
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 80,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 16,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Push (10 ft.)",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d10",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>A briefcase-sized reactor tethers the two-handed thasphalt rifle. The reactor can be worn slung across your body or bound to a backpack.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A briefcase-sized reactor tethers the two-handed thasphalt rifle. The reactor can be worn slung across your body or bound to a backpack.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 16,
+    "modifiers": [],
+    "price": 175000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 100
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 10
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_rifle_light.json
+++ b/src/items/equipment/thasphalt_rifle_light.json
@@ -1,0 +1,255 @@
+{
+  "_id": "FZsTznjt0g6W0zjN",
+  "name": "Thasphalt rifle, light",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": null
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 21
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 80,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 2,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Push (5 ft.)",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "1d10",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>A briefcase-sized reactor tethers the two-handed thasphalt rifle. The reactor can be worn slung across your body or bound to a backpack.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A briefcase-sized reactor tethers the two-handed thasphalt rifle. The reactor can be worn slung across your body or bound to a backpack.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 2,
+    "modifiers": [],
+    "price": 880,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 40
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 1
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasphalt_rifle_tactical.json
+++ b/src/items/equipment/thasphalt_rifle_tactical.json
@@ -1,0 +1,255 @@
+{
+  "_id": "7FSgA9g7X5pJp5bY",
+  "name": "Thasphalt rifle, tactical",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": null
+    },
+    "ammunitionType": "thasphalt",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 80,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 8,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Push (5 ft.)",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d10",
+          "types": {
+            "acid": false,
+            "bludgeoning": true,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>A briefcase-sized reactor tethers the two-handed thasphalt rifle. The reactor can be worn slung across your body or bound to a backpack.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">A briefcase-sized reactor tethers the two-handed thasphalt rifle. The reactor can be worn slung across your body or bound to a backpack.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 8,
+    "modifiers": [],
+    "price": 8500,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": true,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 60
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 4
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasteron_blunderbuss.json
+++ b/src/items/equipment/thasteron_blunderbuss.json
@@ -1,0 +1,255 @@
+{
+  "_id": "wyO2RtsZexfCydpv",
+  "name": "Thasteron blunderbuss",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "kac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "thasteronPellets",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 27
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "1",
+    "capacity": {
+      "max": 50,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 4,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Knockdown",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": true,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>This scattergun-style weapon relies on the propulsion properties of raw thasteron to push targets away from the user.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">This scattergun-style weapon relies on the propulsion properties of raw thasteron to push targets away from the user.</span></p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 4,
+    "modifiers": [],
+    "price": 1350,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": true,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": true,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": true,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 52",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 10
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "uncategorized",
+    "weaponType": "smallA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/thasteron_grenade_i.json
+++ b/src/items/equipment/thasteron_grenade_i.json
@@ -1,0 +1,249 @@
+{
+  "_id": "mSoi73mLFxKu9VDB",
+  "name": "Thasteron grenade I",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 10
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 24
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 3,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed explosive is a favored room-clearing device for special forces.</span></p>\n<p>Explode (staggered, 10 ft.)</p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 3,
+    "modifiers": [],
+    "price": 310,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": "Staggered"
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/holo-grenade.webp"
+}

--- a/src/items/equipment/thasteron_grenade_ii.json
+++ b/src/items/equipment/thasteron_grenade_ii.json
@@ -1,0 +1,249 @@
+{
+  "_id": "4E32NzITFFe3NgHR",
+  "name": "Thasteron grenade II",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 15
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 33
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 6,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed explosive is a favored room-clearing device for special forces.</span></p>\n<p>Explode (staggered, 15 ft.)</p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 6,
+    "modifiers": [],
+    "price": 1350,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": "Staggered"
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/holo-grenade.webp"
+}

--- a/src/items/equipment/thasteron_grenade_iii.json
+++ b/src/items/equipment/thasteron_grenade_iii.json
@@ -1,0 +1,249 @@
+{
+  "_id": "yet3wQ08QN8bBzJF",
+  "name": "Thasteron grenade III",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 20
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 45
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 10,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed explosive is a favored room-clearing device for special forces.</span></p>\n<p>Explode (staggered, 20 ft.)</p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 10,
+    "modifiers": [],
+    "price": 5500,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": "Staggered"
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/holo-grenade.webp"
+}

--- a/src/items/equipment/thasteron_grenade_iv.json
+++ b/src/items/equipment/thasteron_grenade_iv.json
@@ -1,0 +1,249 @@
+{
+  "_id": "JKz96cDvLu1n054S",
+  "name": "Thasteron grenade IV",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 25
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 57
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 14,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed explosive is a favored room-clearing device for special forces.</span></p>\n<p>Explode (staggered, 25 ft.)</p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 14,
+    "modifiers": [],
+    "price": 20500,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": "Staggered"
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/holo-grenade.webp"
+}

--- a/src/items/equipment/thasteron_grenade_v.json
+++ b/src/items/equipment/thasteron_grenade_v.json
@@ -1,0 +1,249 @@
+{
+  "_id": "MkLBTzY4XDaDNPla",
+  "name": "Thasteron grenade V",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "str",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 1
+    },
+    "ammunitionType": "",
+    "area": {
+      "effect": "",
+      "shape": "sphere",
+      "units": "ft",
+      "value": 30
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 99
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 18,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        },
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "amount": 1,
+          "subtype": "ammunitionSlot",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "<p>Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Nicknamed the &ldquo;hole-maker,&rdquo; this raw thasteron-packed explosive is a favored room-clearing device for special forces.</span></p>\n<p>Explode (staggered, 30 ft.)</p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\" />\n<p><strong>Thasteron Weapons:</strong>&nbsp;While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 18,
+    "modifiers": [],
+    "price": 110000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": true,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": true,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": false,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": false,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": false,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": false,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 20
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "reflex",
+      "dc": "(10 + floor(@item.level / 2) + @abilities.dex.mod)",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 51",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": "Staggered"
+    },
+    "usage": {
+      "per": "",
+      "value": null
+    },
+    "uses": {
+      "max": 1,
+      "per": "charges",
+      "value": 1
+    },
+    "weaponCategory": "shock",
+    "weaponType": "grenade"
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/holo-grenade.webp"
+}

--- a/src/items/equipment/thasteron_pellets.json
+++ b/src/items/equipment/thasteron_pellets.json
@@ -1,0 +1,75 @@
+{
+  "_id": "lCrhMYGkjewDJk1q",
+  "name": "Thasteron pellets",
+  "type": "ammunition",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "thasteronPellets",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": null,
+      "value": null
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p>While Sanjaval Spaceflight mostly&nbsp;abandoned its thasteron mines and related manufacturing&nbsp;when Drift travel superseded its industry, it continued to&nbsp;produce sublight starship&nbsp;engines using the dirty fuel.&nbsp;It now enjoys a resurgence&nbsp;in popularity as more people&nbsp;steer away from a reliance on the Drift for&nbsp;intersystem travel. Some of the technological&nbsp;cottage industries that sprung up around thasteron&nbsp;during the collapse of its market have likewise gained&nbsp;popularity.</p>\n<p>Beyond the propulsive properties of thasteron, tactical uses for its nuisance emission, thasteronic asphalt (or thasphalt), have been developed by ysoki engineers. Thasphalt produces force energy and steam when bombarded with strong electromagnetic fields. These fields are too much for internal electronics, so most thasteron weapons are bulky copper, brass, and even leather-and-wood contraptions utilizing clockwork.</p>\n<p><strong>Capacity:</strong> 50</p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "identified": true,
+    "level": 3,
+    "price": 200,
+    "quantity": 50,
+    "quantityPerPack": 50,
+    "source": "DC pg. 51",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "useCapacity": false
+  },
+  "img": "systems/sfrpg/icons/equipment/weapons/nanite-canisters.webp"
+}

--- a/src/items/equipment/transplanar_gluon_blade_astral.json
+++ b/src/items/equipment/transplanar_gluon_blade_astral.json
@@ -1,0 +1,71 @@
+{
+  "_id": "OSxtlhOEpTA16eek",
+  "name": "Transplanar gluon blade, astral",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 53
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 1,
+      "value": 1
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Occasionally, abductees manage to escape from grays with a </span><span class=\"fontstyle2\">transplanar gluon blade</span><span class=\"fontstyle0\">. It resembles a standard box cutter consisting of a plump, hard plastic handle with a short blade that extends out the top while depressing a button, retracted rapidly by a simple spring. Once per day, you can spend 1 minute concentrating with the blade to subtly work it between the seams of reality and cut open a portal to its linked transitive plane. A </span><span class=\"fontstyle2\">transplanar gluon blade </span><span class=\"fontstyle0\">doesn&rsquo;t function if not on the Material Plane or its linked transitive plane. Portals created with the blade close after 1d4 rounds.</span></p>\n<p><span class=\"fontstyle4\"><strong>Astral (Level 18):</strong>&nbsp;</span><span class=\"fontstyle0\">You cut open a portal between the Material Plane and the Astral Plane.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 18,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 450000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "day",
+      "value": 1
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/transplanar_gluon_blade_ethereal.json
+++ b/src/items/equipment/transplanar_gluon_blade_ethereal.json
@@ -1,0 +1,71 @@
+{
+  "_id": "AapfntgNZhHczxoh",
+  "name": "Transplanar gluon blade, ethereal",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 50
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 1,
+      "value": 1
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Occasionally, abductees manage to escape from grays with a </span><span class=\"fontstyle2\">transplanar gluon blade</span><span class=\"fontstyle0\">. It resembles a standard box cutter consisting of a plump, hard plastic handle with a short blade that extends out the top while depressing a button, retracted rapidly by a simple spring. Once per day, you can spend 1 minute concentrating with the blade to subtly work it between the seams of reality and cut open a portal to its linked transitive plane. A </span><span class=\"fontstyle2\">transplanar gluon blade </span><span class=\"fontstyle0\">doesn&rsquo;t function if not on the Material Plane or its linked transitive plane. Portals created with the blade close after 1d4 rounds.</span></p>\n<p><span class=\"fontstyle4\"><strong>Ethereal (Level 15):</strong> </span><span class=\"fontstyle0\">You cut open a portal between the Material Plane and the Ethereal Plane.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 15,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 135000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "day",
+      "value": 1
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/transplanar_gluon_blade_shadow.json
+++ b/src/items/equipment/transplanar_gluon_blade_shadow.json
@@ -1,0 +1,71 @@
+{
+  "_id": "5NJ59y06jJG1NO43",
+  "name": "Transplanar gluon blade, shadow",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 55
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 1,
+      "value": 1
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">Occasionally, abductees manage to escape from grays with a </span><span class=\"fontstyle2\">transplanar gluon blade</span><span class=\"fontstyle0\">. It resembles a standard box cutter consisting of a plump, hard plastic handle with a short blade that extends out the top while depressing a button, retracted rapidly by a simple spring. Once per day, you can spend 1 minute concentrating with the blade to subtly work it between the seams of reality and cut open a portal to its linked transitive plane. A </span><span class=\"fontstyle2\">transplanar gluon blade </span><span class=\"fontstyle0\">doesn&rsquo;t function if not on the Material Plane or its linked transitive plane. Portals created with the blade close after 1d4 rounds.</span></p>\n<p><strong><span class=\"fontstyle4\">Shadow (Level 20</span><span class=\"fontstyle0\">)</span></strong><span class=\"fontstyle4\"><strong>:</strong>&nbsp;</span><span class=\"fontstyle0\">You cut open a portal between the Material Plane and the Shadow Plane.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 20,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 1100000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 55",
+    "usage": {
+      "per": "day",
+      "value": 1
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/trenarii_singing_coil_duet.json
+++ b/src/items/equipment/trenarii_singing_coil_duet.json
@@ -1,0 +1,255 @@
+{
+  "_id": "BcKl7yS71fMygPjK",
+  "name": "Trenarii singing coil, duet",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 39
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 40,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 8,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "2d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">The pahtras of Trenarez consider themselves the bleeding edge of pahtra musical innovation, and their latest hit is using carefully modulated electrical coils to emit lightning bolts that replicate musical tones. It wasn&rsquo;t long before someone created a portable version, allowing the user to spread destruction to jaunty musical accompaniment.</span></p>\n<p><strong>Profession (Musician)<sup>AR</sup></strong></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 8,
+    "modifiers": [],
+    "price": 9700,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": true,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": true,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": true,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 90
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 63",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 8
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/trenarii_singing_coil_orchestra.json
+++ b/src/items/equipment/trenarii_singing_coil_orchestra.json
@@ -1,0 +1,255 @@
+{
+  "_id": "wC1QVdlYMumoqvup",
+  "name": "Trenarii singing coil, orchestra",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 99
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 100,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 18,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Deafen",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "7d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">The pahtras of Trenarez consider themselves the bleeding edge of pahtra musical innovation, and their latest hit is using carefully modulated electrical coils to emit lightning bolts that replicate musical tones. It wasn&rsquo;t long before someone created a portable version, allowing the user to spread destruction to jaunty musical accompaniment.</span></p>\n<p><strong>Profession (Musician)<sup>AR</sup></strong></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 18,
+    "modifiers": [],
+    "price": 380000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": true,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": true,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": true,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 200
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 63",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 10
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/trenarii_singing_coil_quartet.json
+++ b/src/items/equipment/trenarii_singing_coil_quartet.json
@@ -1,0 +1,255 @@
+{
+  "_id": "M2a3b50bIta0BcCu",
+  "name": "Trenarii singing coil, quartet",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 54
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 80,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 13,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "Deafen",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "4d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">The pahtras of Trenarez consider themselves the bleeding edge of pahtra musical innovation, and their latest hit is using carefully modulated electrical coils to emit lightning bolts that replicate musical tones. It wasn&rsquo;t long before someone created a portable version, allowing the user to spread destruction to jaunty musical accompaniment.</span></p>\n<p><strong>Profession (Musician)<sup>AR</sup></strong></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 13,
+    "modifiers": [],
+    "price": 50000,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": true,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": true,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": true,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 120
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 63",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 10
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/trenarii_singing_coil_solo.json
+++ b/src/items/equipment/trenarii_singing_coil_solo.json
@@ -1,0 +1,255 @@
+{
+  "_id": "uCqdADSKzhMYSaUo",
+  "name": "Trenarii singing coil, solo",
+  "type": "weapon",
+  "data": {
+    "type": "",
+    "ability": "dex",
+    "abilityMods": {
+      "parts": []
+    },
+    "actionTarget": "eac",
+    "actionType": "rwak",
+    "activation": {
+      "type": "action",
+      "condition": "",
+      "cost": 0
+    },
+    "ammunitionType": "charge",
+    "area": {
+      "effect": "",
+      "shape": "",
+      "units": "none",
+      "value": null
+    },
+    "attackBonus": 0,
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 27
+      },
+      "size": "medium",
+      "sturdy": true
+    },
+    "attuned": false,
+    "bulk": "2",
+    "capacity": {
+      "max": 20,
+      "value": 0
+    },
+    "chatFlavor": "",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "fusion"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 4,
+          "subtype": "fusion",
+          "weightProperty": "level"
+        }
+      ]
+    },
+    "critical": {
+      "effect": "",
+      "parts": []
+    },
+    "damage": {
+      "parts": [
+        {
+          "name": "",
+          "formula": "1d4",
+          "types": {
+            "acid": false,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": true,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
+          }
+        }
+      ]
+    },
+    "damageNotes": "",
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">The pahtras of Trenarez consider themselves the bleeding edge of pahtra musical innovation, and their latest hit is using carefully modulated electrical coils to emit lightning bolts that replicate musical tones. It wasn&rsquo;t long before someone created a portable version, allowing the user to spread destruction to jaunty musical accompaniment.</span></p>\n<p><strong>Profession (Musician)<sup>AR</sup></strong></p>"
+    },
+    "descriptors": [],
+    "duration": {
+      "units": "",
+      "value": ""
+    },
+    "equippable": true,
+    "equipped": false,
+    "formula": "",
+    "identified": true,
+    "isActive": null,
+    "level": 4,
+    "modifiers": [],
+    "price": 2200,
+    "proficient": false,
+    "properties": {
+      "aeon": false,
+      "amm": false,
+      "analog": false,
+      "antibiological": false,
+      "archaic": false,
+      "aurora": false,
+      "automatic": false,
+      "blast": false,
+      "block": false,
+      "boost": false,
+      "breach": false,
+      "breakdown": false,
+      "bright": false,
+      "buttressing": false,
+      "cluster": false,
+      "conceal": false,
+      "deconstruct": false,
+      "deflect": false,
+      "disarm": false,
+      "double": false,
+      "drainCharge": false,
+      "echo": false,
+      "entangle": false,
+      "explode": false,
+      "extinguish": false,
+      "feint": false,
+      "fiery": false,
+      "firstArc": false,
+      "flexibleLine": false,
+      "force": false,
+      "freeHands": false,
+      "fueled": false,
+      "gearArray": false,
+      "grapple": false,
+      "gravitation": false,
+      "guided": false,
+      "harrying": false,
+      "holyWater": false,
+      "hybrid": false,
+      "ignite": false,
+      "indirect": false,
+      "injection": false,
+      "integrated": false,
+      "line": true,
+      "living": false,
+      "lockdown": false,
+      "mind-affecting": false,
+      "mine": false,
+      "mire": false,
+      "modal": false,
+      "necrotic": false,
+      "nonlethal": false,
+      "one": false,
+      "operative": false,
+      "penetrating": false,
+      "polarize": false,
+      "polymorphic": false,
+      "powered": false,
+      "professional": true,
+      "propel": false,
+      "punchGun": false,
+      "qreload": false,
+      "radioactive": false,
+      "reach": false,
+      "recall": false,
+      "regrowth": false,
+      "relic": false,
+      "reposition": false,
+      "scramble": false,
+      "shape": false,
+      "shatter": false,
+      "shells": false,
+      "shield": false,
+      "sniper": false,
+      "stun": false,
+      "subtle": false,
+      "sunder": false,
+      "swarm": false,
+      "tail": false,
+      "teleportive": false,
+      "thought": false,
+      "throttle": false,
+      "thrown": false,
+      "thruster": false,
+      "trip": false,
+      "two": true,
+      "unbalancing": false,
+      "underwater": false,
+      "unwieldy": true,
+      "variantBoost": false,
+      "wideLine": false
+    },
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "range": {
+      "additional": "",
+      "per": "",
+      "units": "ft",
+      "value": 60
+    },
+    "rollNotes": "",
+    "save": {
+      "type": "",
+      "dc": "",
+      "descriptor": "negate"
+    },
+    "source": "DC pg. 63",
+    "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
+    "target": {
+      "type": "",
+      "value": ""
+    },
+    "usage": {
+      "per": "shot",
+      "value": 5
+    },
+    "uses": {
+      "max": 0,
+      "per": "",
+      "value": 0
+    },
+    "weaponCategory": "shock",
+    "weaponType": "longA"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/void_projector.json
+++ b/src/items/equipment/void_projector.json
@@ -1,0 +1,71 @@
+{
+  "_id": "EvIMwcTmJZLD4lUX",
+  "name": "Void projector",
+  "type": "hybrid",
+  "data": {
+    "type": "",
+    "abilityMods": {
+      "parts": []
+    },
+    "ammunitionType": "",
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 13
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "L",
+    "capacity": {
+      "max": 10,
+      "value": 10
+    },
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">As a standard action, you can activate a </span><span class=\"fontstyle2\">void projector </span><span class=\"fontstyle0\">to transform a 20-foot-radius area into a zero-g environment. The area has no gravity. A </span><span class=\"fontstyle2\">void projector </span><span class=\"fontstyle0\">can operate for up to 10 minutes per day. This duration need not be continuous, but it must be used in 1-minute increments. The device has a timer, which you can set as a move action, that enables the </span><span class=\"fontstyle2\">void projector </span><span class=\"fontstyle0\">to operate for a set number of minutes. You can deactivate a </span><span class=\"fontstyle2\">void projector </span><span class=\"fontstyle0\">as a swift action.</span></p>"
+    },
+    "equippable": false,
+    "equipped": false,
+    "hands": 0,
+    "identified": true,
+    "level": 8,
+    "limitedWear": false,
+    "modifiers": [],
+    "price": 8500,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 93",
+    "usage": {
+      "per": "minute",
+      "value": 1
+    }
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/withered_lungs_mk_1.json
+++ b/src/items/equipment/withered_lungs_mk_1.json
@@ -1,0 +1,77 @@
+{
+  "_id": "me3in9gQQ5SCHFz8",
+  "name": "Withered lungs Mk 1",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 6
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">These scarred, shriveled lungs allow you to breathe normally, yet they especially thrive when exposed to harmful airborne effect, such as smoke or an inhaled affliction. As a move action while in the area of an airborne hazard, you can inhale deeply, eliminating the airborne hazard from your space as well as from a number of contiguous 5-foot cubes equal to twice the augmentation&rsquo;s model. Doing so exposes you to the hazard, though you gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard. Upon absorbing a hazard in this way, the lungs process the material into vital energy, and you regain a number of Stamina Points equal to twice the hazard&rsquo;s CR, twice the level of the item that created the hazard, or twice the CR of the creature that created the effect. Once you inhale a hazard in this way, you cannot do so again until you have rested for 10 minutes to regain Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 1,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Withered lungs",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "You gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard that you inhaled using your Withered lungs.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 200,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "lungs"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/withered_lungs_mk_2.json
+++ b/src/items/equipment/withered_lungs_mk_2.json
@@ -1,0 +1,77 @@
+{
+  "_id": "0HsLi3Oplw7qdrDs",
+  "name": "Withered lungs Mk 2",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 11
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">These scarred, shriveled lungs allow you to breathe normally, yet they especially thrive when exposed to harmful airborne effect, such as smoke or an inhaled affliction. As a move action while in the area of an airborne hazard, you can inhale deeply, eliminating the airborne hazard from your space as well as from a number of contiguous 5-foot cubes equal to twice the augmentation&rsquo;s model. Doing so exposes you to the hazard, though you gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard. Upon absorbing a hazard in this way, the lungs process the material into vital energy, and you regain a number of Stamina Points equal to twice the hazard&rsquo;s CR, twice the level of the item that created the hazard, or twice the CR of the creature that created the effect. Once you inhale a hazard in this way, you cannot do so again until you have rested for 10 minutes to regain Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 6,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Withered lungs",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "You gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard that you inhaled using your Withered lungs.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 4000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "lungs"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/withered_lungs_mk_3.json
+++ b/src/items/equipment/withered_lungs_mk_3.json
@@ -1,0 +1,77 @@
+{
+  "_id": "92eq1MGc2xNjhygw",
+  "name": "Withered lungs Mk 3",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 17
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">These scarred, shriveled lungs allow you to breathe normally, yet they especially thrive when exposed to harmful airborne effect, such as smoke or an inhaled affliction. As a move action while in the area of an airborne hazard, you can inhale deeply, eliminating the airborne hazard from your space as well as from a number of contiguous 5-foot cubes equal to twice the augmentation&rsquo;s model. Doing so exposes you to the hazard, though you gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard. Upon absorbing a hazard in this way, the lungs process the material into vital energy, and you regain a number of Stamina Points equal to twice the hazard&rsquo;s CR, twice the level of the item that created the hazard, or twice the CR of the creature that created the effect. Once you inhale a hazard in this way, you cannot do so again until you have rested for 10 minutes to regain Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 12,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Withered lungs",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "You gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard that you inhaled using your Withered lungs.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 30000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "lungs"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/withered_lungs_mk_4.json
+++ b/src/items/equipment/withered_lungs_mk_4.json
@@ -1,0 +1,77 @@
+{
+  "_id": "kLHWoTKjOvQTg1lZ",
+  "name": "Withered lungs Mk 4",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 53
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">These scarred, shriveled lungs allow you to breathe normally, yet they especially thrive when exposed to harmful airborne effect, such as smoke or an inhaled affliction. As a move action while in the area of an airborne hazard, you can inhale deeply, eliminating the airborne hazard from your space as well as from a number of contiguous 5-foot cubes equal to twice the augmentation&rsquo;s model. Doing so exposes you to the hazard, though you gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard. Upon absorbing a hazard in this way, the lungs process the material into vital energy, and you regain a number of Stamina Points equal to twice the hazard&rsquo;s CR, twice the level of the item that created the hazard, or twice the CR of the creature that created the effect. Once you inhale a hazard in this way, you cannot do so again until you have rested for 10 minutes to regain Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 18,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Withered lungs",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "You gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard that you inhaled using your Withered lungs.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 350000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "lungs"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}

--- a/src/items/equipment/withered_lungs_mk_5.json
+++ b/src/items/equipment/withered_lungs_mk_5.json
@@ -1,0 +1,77 @@
+{
+  "_id": "qBOZrImyJPEVNGQu",
+  "name": "Withered lungs Mk 5",
+  "type": "augmentation",
+  "data": {
+    "type": "necrograft",
+    "abilityMods": {
+      "parts": []
+    },
+    "attributes": {
+      "ac": {
+        "value": ""
+      },
+      "customBuilt": false,
+      "dex": {
+        "mod": ""
+      },
+      "hardness": {
+        "value": ""
+      },
+      "hp": {
+        "max": "",
+        "value": 55
+      },
+      "size": "medium",
+      "sturdy": false
+    },
+    "attuned": false,
+    "bulk": "0",
+    "container": {
+      "contents": [],
+      "includeContentsInWealthCalculation": true,
+      "isOpen": true,
+      "storage": []
+    },
+    "critical": {
+      "parts": []
+    },
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "gmnotes": "",
+      "short": "",
+      "unidentified": "",
+      "value": "<p><span class=\"fontstyle0\">These scarred, shriveled lungs allow you to breathe normally, yet they especially thrive when exposed to harmful airborne effect, such as smoke or an inhaled affliction. As a move action while in the area of an airborne hazard, you can inhale deeply, eliminating the airborne hazard from your space as well as from a number of contiguous 5-foot cubes equal to twice the augmentation&rsquo;s model. Doing so exposes you to the hazard, though you gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard. Upon absorbing a hazard in this way, the lungs process the material into vital energy, and you regain a number of Stamina Points equal to twice the hazard&rsquo;s CR, twice the level of the item that created the hazard, or twice the CR of the creature that created the effect. Once you inhale a hazard in this way, you cannot do so again until you have rested for 10 minutes to regain Stamina Points.</span></p>"
+    },
+    "equippable": true,
+    "equipped": false,
+    "identified": true,
+    "level": 20,
+    "modifiers": [
+      {
+        "_id": "81488c25-391f-4b45-859d-8b355301b138",
+        "name": "Withered lungs",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "saves",
+        "enabled": false,
+        "max": 4,
+        "modifier": "4",
+        "modifierType": "formula",
+        "notes": "You gain a +4 enhancement bonus to any saving throw to resist initial exposure to the hazard that you inhaled using your Withered lungs.",
+        "source": "",
+        "subtab": "misc",
+        "valueAffected": "ste"
+      }
+    ],
+    "price": 775000,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "DC pg. 73",
+    "system": "lungs"
+  },
+  "img": "icons/svg/mystery-man.svg"
+}


### PR DESCRIPTION
Added all Drift Crisis equipment/gear. (Minus Aeon stones, See #645 PR)
This PR is depending on LebombJames' Ammunition type update #644 