### PR TITLE
Fix infinite rerender on item sheet if saving throw bonus = 0

### DIFF
--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -135,7 +135,7 @@ export class ItemSheetSFRPG extends ItemSheet {
 
                 data.placeholders.savingThrow = data.placeholders.savingThrow || {};
                 data.placeholders.savingThrow.formula = `@itemLevel + @owner.abilities.dex.mod`;
-                data.placeholders.savingThrow.value = data.placeholders.savingThrow.value || 10;
+                data.placeholders.savingThrow.value = data.placeholders.savingThrow.value ?? 10;
                 
                 this.item.data.flags.placeholders = data.placeholders;
                 this._computeSavingThrowValue(itemLevel, data.placeholders.savingThrow.formula)
@@ -154,7 +154,7 @@ export class ItemSheetSFRPG extends ItemSheet {
 
                 data.placeholders.savingThrow = data.placeholders.savingThrow || {};
                 data.placeholders.savingThrow.formula = `@itemLevel + @owner.abilities.dex.mod`;
-                data.placeholders.savingThrow.value = data.placeholders.savingThrow.value || 10;
+                data.placeholders.savingThrow.value = data.placeholders.savingThrow.value ?? 10;
                 
                 this.item.data.flags.placeholders = data.placeholders;
                 this._computeSavingThrowValue(itemLevel, data.placeholders.savingThrow.formula)


### PR DESCRIPTION
Currently, level 0 items, and you having a -1 dex mod causes some item sheets to infinitely re-render. I tracked this down to being caused by the total bonus equaling 0, which is technically falsy, causing line 138 to return 10. That isn't equal to the newSavingThrowValue, so the function repeats. Using `??` instead fixes it, as it doesn't defer to the right value on a 0.

In conclusion: ffs javascript.