### PR TITLE
Prettify roll formulas on chat cards

### DIFF
--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -712,6 +712,7 @@ export class DiceSFRPG {
 
             const rollObject = Roll.create(finalFormula.finalRoll, { tags: tags, breakdown: preparedRollExplanation });
             let roll = await rollObject.evaluate({async: true});
+            roll._formula = this.simplifyRollFormula(roll);
             
             //CRB pg. 240, < 1 damage returns 1 non-lethal damage.
             if (roll._total < 1) {
@@ -973,5 +974,24 @@ export class DiceSFRPG {
         }
 
         return resolveResult;
+    }
+    
+    /**
+    * Replace functions in roll terms (such as floor, max, lookupRange) with their result.
+    * @param {Roll}     roll                    The data for the roll.
+    * @returns {string} simplerRoll._formula    The cleaned up formula
+    */
+    static simplifyRollFormula(roll) {
+        console.log(roll)
+        const terms = Roll.parse(roll.formula);
+        const simpler = terms.map(t => {
+            if (t instanceof MathTerm && t.isDeterministic) {
+                return new NumericTerm({number: t.total})
+            }
+            return t;
+        });
+        const simplerRoll = Roll.fromTerms(simpler);
+        
+        return simplerRoll._formula;
     }
 }

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -712,7 +712,6 @@ export class DiceSFRPG {
 
             const rollObject = Roll.create(finalFormula.finalRoll, { tags: tags, breakdown: preparedRollExplanation });
             let roll = await rollObject.evaluate({async: true});
-            roll._formula = this.simplifyRollFormula(roll);
             
             //CRB pg. 240, < 1 damage returns 1 non-lethal damage.
             if (roll._total < 1) {
@@ -974,24 +973,5 @@ export class DiceSFRPG {
         }
 
         return resolveResult;
-    }
-    
-    /**
-    * Replace functions in roll terms (such as floor, max, lookupRange) with their result.
-    * @param {Roll}     roll                    The data for the roll.
-    * @returns {string} simplerRoll._formula    The cleaned up formula
-    */
-    static simplifyRollFormula(roll) {
-        console.log(roll)
-        const terms = Roll.parse(roll.formula);
-        const simpler = terms.map(t => {
-            if (t instanceof MathTerm && t.isDeterministic) {
-                return new NumericTerm({number: t.total})
-            }
-            return t;
-        });
-        const simplerRoll = Roll.fromTerms(simpler);
-        
-        return simplerRoll._formula;
     }
 }

--- a/src/module/rolls/roll.js
+++ b/src/module/rolls/roll.js
@@ -64,7 +64,7 @@ export default class SFRPGRoll extends Roll {
 
         // Define chat data
         const chatData = {
-            formula: isPrivate ? "???" : this._formula,
+            formula: isPrivate ? "???" : this.formula,
             flavor: isPrivate ? null : chatOptions.flavor,
             user: chatOptions.user,
             tooltip: isPrivate ? "" : await this.getTooltip(),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/77904738/183290364-34c766c1-22c0-4d96-84ca-0f48a67028b9.png)

First card is with the change, second is without.

`roll.formula` produces a cleaned up formula already, whereas `roll._formula` doesn't, so changing chat cards to use the former is a very easy fix.