### PR TITLE
replace `toObject` with `deepClone` for item merge comparison

### DIFF
--- a/changelist.md
+++ b/changelist.md
@@ -24,6 +24,7 @@ As there are a number of breaking changes between foundry v12 and v13, this vers
 - Fixes for how weapon specialization is calculated by @Theleruby
 - Fix starship roll options by @danimrath
 - Fix Vite config minification bugs by @danimrath
+- Fix item stacks (like ammo) not merging correctly by @ian612
 
 ## Data Entry
 Along with a host of fixes to items and aliens in the compendiums, a big effort has been put forth to update all the system's weapons and grenades to use modern attributes. In addition, more Enhanced data (Themes, Archetypes, and Equipment) has been entered. Big thanks to @ilya-vasiuk, @joharr79, @rmorgens, and @Theleruby for these major contributions!

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -428,10 +428,10 @@ function canMerge(itemA, itemB) {
     }
 
     // Perform deep comparison on item data.
-    const itemDataA = itemA.system.toObject();
+    const itemDataA = foundry.utils.deepClone(itemA.system);
     delete itemDataA.quantity;
 
-    const itemDataB = itemB.system.toObject();
+    const itemDataB = foundry.utils.deepClone(itemB.system);
     delete itemDataB.quantity;
 
     // TODO: Remove all keys that are not template appropriate given the item type, remove all keys that are not shared?


### PR DESCRIPTION
Using `.toObject()` seemed to be throwing errors for me when trying to combine items in an inventory via dragging, resulting in stacks of identical items not combining properly. This fix replaces that call with the foundry `deepClone()` utility, which does work.