### PR TITLE
Change document browser item list back to Map() type

### DIFF
--- a/src/module/packs/document-browser.js
+++ b/src/module/packs/document-browser.js
@@ -259,7 +259,7 @@ export class DocumentBrowserSFRPG extends Application {
     async loadItems() {
         console.log('Starfinder | Compendium Browser | Started loading items');
         /** @type {Collection<string, {uuid: string, img: string, name: string, system: object, type: string}>} */
-        const items = new Collection();
+        const items = new Map();
         const user = game.user;
         const userPermission = user.isGM ? "GAMEMASTER" : (user.isTrusted ? "TRUSTED" : "PLAYER");
 


### PR DESCRIPTION
Fixes a bug with the document browser not showing items correctly