### PR TITLE
Fix timed effects not working correctly on unlinked tokens

### DIFF
--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -834,7 +834,7 @@ export class CombatSFRPG extends foundry.documents.Combat {
             const effectFinish = duration.activationEnd ?? Infinity;
             const expiryInit = duration.expiryInit || 1000; // If anything goes wrong, expire at the start of the round
             const targetActorUuid = (() => {
-                /** @type {"parent"|"origin"|"init"|ActorID} */
+                /** @type {"parent"|"origin"|"init"|ActorID|ActorUUID} */
                 const expiryModeTurn = duration.expiryMode.turn;
 
                 // Expire on the owner's turn
@@ -852,8 +852,14 @@ export class CombatSFRPG extends foundry.documents.Combat {
                 // Turn closest to initiative to expire on
                 else if (expiryModeTurn === "init") return this.combatants.contents.sort(this._sortCombatants).find(c => c.initiative <= expiryInit).actor.uuid;
 
-                // Otherwise, an actor id of a specific combatant
-                else return expiryModeTurn;
+                else {
+                    // If this is the ID of an actor then we return that actor's uuid
+                    const combatant = this.combatants.find(c => c.actorId === expiryModeTurn);
+                    if (combatant) return combatant.actor.uuid;
+
+                    // Otherwise, an actor uuid of a specific combatant
+                    return expiryModeTurn;
+                }
             })();
 
             if (((worldTime >= effectFinish) && effect.enabled) // If effect has expired

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -250,13 +250,13 @@ export class ItemSheetSFRPG extends foundry.appv1.sheets.ItemSheet {
             data.sourceActorChoices = {};
             if (game.combat?.started) {
                 for (const combatant of game.combat.combatants) {
-                    if (combatant.actorId === data.item?.actor?.id) continue;
-                    data.sourceActorChoices[combatant.actorId] = combatant.name;
+                    if (combatant.actor.uuid === data.item?.actor?.uuid) continue;
+                    data.sourceActorChoices[combatant.actor.uuid] = combatant.name;
                 }
             } else {
                 const PCs = game.actors.filter(i => i.type === "character");
                 for (const PC of PCs) {
-                    data.sourceActorChoices[PC.id] = PC.name;
+                    data.sourceActorChoices[PC.uuid] = PC.name;
                 }
             }
 

--- a/src/module/timedEffect/timedEffect.js
+++ b/src/module/timedEffect/timedEffect.js
@@ -66,7 +66,7 @@ export default class SFRPGTimedEffect {
             expiryMode: {
                 /** @type {"turn"|"init"} Expire on a combatant's turn, or a specific init count. */
                 type: "turn",
-                /** @type {"parent"|"origin"|"init"|ActorID} If type is `turn`, which turn to expire on. */
+                /** @type {"parent"|"origin"|"init"|ActorID|ActorUUID} If type is `turn`, which turn to expire on. */
                 turn: "parent"
             },
             expiryInit: 0,


### PR DESCRIPTION
The timed effects currently don't work correctly in combats involving multiple unlinked tokens of the same actor. This is because the _handleTimedEffects method uses the actor ID when handling turn changes, which is obviously the same for every copy of the actor in combat. This PR attempts to fix the issue by changing the timed effects system to use the UUID instead (which for unlinked tokens also contains the scene and token IDs).