### PR TITLE
Fix gunnery check in some starship actions not including skills.gun.mod

### DIFF
--- a/src/items/starship-actions/encourage.json
+++ b/src/items/starship-actions/encourage.json
@@ -33,7 +33,7 @@
       },
       {
         "name": "Gunnery",
-        "formula": "max(@captain.attributes.baseAttackBonus.value, @captain.skills.pil.ranks) + @captain.abilities.dex.mod"
+        "formula": "max(@captain.attributes.baseAttackBonus.value, @captain.skills.pil.ranks, @captain.skills.gun.mod) + @captain.abilities.dex.mod"
       },
       {
         "name": "Piloting",

--- a/src/items/starship-actions/harrying_shot.json
+++ b/src/items/starship-actions/harrying_shot.json
@@ -21,7 +21,7 @@
     "formula": [
       {
         "name": "Gunnery",
-        "formula": "max(@minorCrew.attributes.baseAttackBonus.value, @minorCrew.skills.pil.ranks) + @minorCrew.abilities.dex.mod"
+        "formula": "max(@minorCrew.attributes.baseAttackBonus.value, @minorCrew.skills.pil.ranks, @minorCrew.skills.gun.mod) + @minorCrew.abilities.dex.mod"
       }
     ],
     "isPush": false,

--- a/src/items/starship-actions/orders.json
+++ b/src/items/starship-actions/orders.json
@@ -29,7 +29,7 @@
       },
       {
         "name": "Gunnery",
-        "formula": "max(@captain.attributes.baseAttackBonus.value, @captain.skills.pil.ranks) + @captain.abilities.dex.mod"
+        "formula": "max(@captain.attributes.baseAttackBonus.value, @captain.skills.pil.ranks, @captain.skills.gun.mod) + @captain.abilities.dex.mod"
       },
       {
         "name": "Piloting",

--- a/src/items/starship-actions/snap_shot.json
+++ b/src/items/starship-actions/snap_shot.json
@@ -18,7 +18,7 @@
     "formula": [
       {
         "name": "Gunnery",
-        "formula": "max(@minorCrew.attributes.baseAttackBonus.value, @minorCrew.skills.pil.ranks) + @minorCrew.abilities.dex.mod - 2"
+        "formula": "max(@minorCrew.attributes.baseAttackBonus.value, @minorCrew.skills.pil.ranks, @minorCrew.skills.gun.mod) + @minorCrew.abilities.dex.mod - 2"
       }
     ],
     "isPush": false,


### PR DESCRIPTION
The NPC starship stat block allows for crew members other than the gunner to have a gunnery modifier. Four starship actions (Encourage, Harrying Shot, Orders and Snap Shot) are missing that modifier from their formula, causing them to roll incorrectly if such a modifier is set for the crew member using those actions. This PR fixes that issue.