### PR TITLE
Fix attack string calculation error on actor sheets

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -458,6 +458,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
         try {
             const itemData = item.system;
             const actor = item.actor;
+            const actorData = actor.system;
             const isWeapon = ["weapon", "shield"].includes(item.type);
 
             // TODO: This chunk is the same code as in item.js's rollAttack(), probably good practice to combine these into one method somewhere
@@ -518,7 +519,9 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             const roll = Roll.create(preparedFormula, rollData).simplifiedFormula;
             item.config.attackString = Number(roll) >= 0 ? `+${roll}` : roll;
 
-        } catch {
+        } catch (err) {
+            console.debug("Issue with calculating an attack string");
+            console.debug(err);
             item.config.attackString = game.i18n.localize("SFRPG.Attack");
         }
     }

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -868,9 +868,9 @@ export class ItemSFRPG extends Mix(foundry.documents.Item).with(ItemActivationMi
      */
     async rollAttack(options = {}) {
         const itemData = this.system;
+        const actorData = this.actor.system;
         const isWeapon = ["weapon", "shield"].includes(this.type);
 
-        const actorData = this.actor.system;
         if (!this.hasAttack) {
             ui.notifications.error("You may not make an Attack Roll with this Item.");
             return;


### PR DESCRIPTION
Fixes an issue missed in #1665 cause by `actorData` being referenced but not defined during sheet preparation. This was causing attack strings to be calculated as the default "Attack" rather than the attack bonus when the error was caught for some items.