### PR TITLE
Close/Medium/Long range calculation on item sheets

### DIFF
--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -183,6 +183,7 @@ export class ItemSheetSFRPG extends foundry.appv1.sheets.ItemSheet {
                 else return !(["none", "personal", "touch", "planetary", "system", "plane", "unlimited"].includes(itemData.range.units));
             })();
             data.range.showTotal = !!itemData.range?.total && (String(itemData.range?.total) !== String(itemData.range?.value));
+            data.range.total = itemData.range?.total;
 
             data.area = {};
             data.area.showTotal = !!itemData.area?.total && (String(itemData.area?.total) !== String(itemData.area?.value));

--- a/static/templates/items/parts/item-activation.hbs
+++ b/static/templates/items/parts/item-activation.hbs
@@ -86,7 +86,7 @@
                 <div class="form-group input-select">
                     <label>{{#if (eq this.data.type "weapon")}}{{ localize "SFRPG.Items.Activation.RangeIncrement" }}{{else}}{{ localize "SFRPG.Items.Activation.Range" }}{{/if}}</label>
                     <div class="form-fields">
-                        {{#if this.range.showTotal}}<p class="calculated-total"><strong>{{itemData.range.total}}</strong></p>{{/if}}
+                        {{#if this.range.showTotal}}<p class="calculated-total"><strong>{{this.range.total}} {{localize "SFRPG.Units.Speed"}}</strong></p>{{/if}}
                         {{#if this.range.hasInput}}
                         <input class="wide-form-field" type="text" name="system.range.value" value="{{itemData.range.value}}" data-dtype="String" placeholder="Range"/>
                         {{/if}}


### PR DESCRIPTION
This fixes the calculation of Close/Medium/Long ranges displayed on item sheets for spells that belong to actors.
<img width="971" height="565" alt="image" src="https://github.com/user-attachments/assets/b5f4dc3b-8ae0-40a8-8f36-ea383b8c638f" />
