### PR TITLE
Simplify the number on Die terms in simplified formulas

### DIFF
--- a/src/module/rolls/roll.js
+++ b/src/module/rolls/roll.js
@@ -61,6 +61,17 @@ export default class SFRPGRoll extends Roll {
                 }
                 return new terms.NumericTerm({number: total});
             }
+            if (t instanceof terms.Die) {
+                if (t._number.isDeterministic) {
+                    let total = 0;
+                    try {
+                        total = t?.total || Roll.safeEval(t._number);
+                    } catch {
+                        total = Roll.safeEval(t._number);
+                    }
+                    return new terms.Die({faces: t.faces, number: total});
+                }
+            }
             return t;
         });
         return DiceSFRPG.simplifyRollFormula(Roll.fromTerms(newterms).formula) || "0";


### PR DESCRIPTION
Adds simplification for the `number` value of `Die` terms when simplifying formulas. This changes the display of terms that preced dice from:
<img width="896" height="78" alt="image" src="https://github.com/user-attachments/assets/8eb2c85b-81d4-48af-806b-a84846d2930b" />
to the correctly simplified:
<img width="892" height="74" alt="image" src="https://github.com/user-attachments/assets/68d56495-3da8-411b-b678-0ee286e287e2" />
