### PR TITLE
Calculate bulk of UPBs (1 per 1000)

### DIFF
--- a/src/module/rules/actions/actor/calculate-bulk-and-wealth.js
+++ b/src/module/rules/actions/actor/calculate-bulk-and-wealth.js
@@ -285,6 +285,10 @@ export default function(engine) {
             // console.log(`> ${item.name} has a total weight of ${itemBulk}, bringing the sum to ${totalWeight}`);
         }
 
+        // Calculate bulk of UPBs
+        const upbWeight = Math.floor((data.currency?.upb ?? 0) / 1000) * 10; // 1000 UPBs per bulk, but multiply by 10 for integer-space bulk calculation
+        totalWeight += upbWeight;
+
         actorData.bulk = Math.floor(totalWeight / 10); // Divide bulk by 10 to correct for integer-space bulk calculation.
         actorData.wealth = computeWealthForActor(actor, totalWealth);
 

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -199,7 +199,8 @@
                 "Encumbrance": {
                     "Encumbrance": "Traglast",
                     "EncumbranceBaseTooltip": "Traglast: {base} (Strength)",
-                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})"
+                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})",
+                    "ItemsAndUPBs": "Items and UPBs"
                 },
                 "Interface": {
                     "AmountToTransferInfo": "Minimum 1, Maximum {max}",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -199,7 +199,8 @@
                 "Encumbrance": {
                     "Encumbrance": "Encumbrance",
                     "EncumbranceBaseTooltip": "Encumbrance Base: {base} (Strength)",
-                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})"
+                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})",
+                    "ItemsAndUPBs": "Items and UPBs"
                 },
                 "Interface": {
                     "AmountToTransferInfo": "Minimum 1, maximum {max}",

--- a/static/lang/es.json
+++ b/static/lang/es.json
@@ -200,7 +200,8 @@
                 "Encumbrance": {
                     "Encumbrance": "Encumbrance",
                     "EncumbranceBaseTooltip": "Encumbrance Base: {base} (Strength)",
-                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})"
+                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})",
+                    "ItemsAndUPBs": "Items and UPBs"
                 },
                 "Interface": {
                     "AmountToTransferInfo": "Minimum 1, maximum {max}",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -199,7 +199,8 @@
                 "Encumbrance": {
                     "Encumbrance": "Encombrement",
                     "EncumbranceBaseTooltip": "Encombrement de base: {base} (Strength)",
-                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})"
+                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})",
+                    "ItemsAndUPBs": "Items and UPBs"
                 },
                 "Interface": {
                     "AmountToTransferInfo": "Minimum 1, maximum {max}",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -199,7 +199,8 @@
                 "Encumbrance": {
                     "Encumbrance": "Capacità di Trasporto",
                     "EncumbranceBaseTooltip": "Capacità di Trasporto di base: {base} (Strength)",
-                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})"
+                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})",
+                    "ItemsAndUPBs": "Items and UPBs"
                 },
                 "Interface": {
                     "AmountToTransferInfo": "Minimo 1, Massimo {max}",

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -199,7 +199,8 @@
                 "Encumbrance": {
                     "Encumbrance": "Encumbrance",
                     "EncumbranceBaseTooltip": "Encumbrance Base: {base} (Strength)",
-                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})"
+                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})",
+                    "ItemsAndUPBs": "Items and UPBs"
                 },
                 "Interface": {
                     "AmountToTransferInfo": "Minimum 1, maximum {max}",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -199,7 +199,8 @@
                 "Encumbrance": {
                     "Encumbrance": "Sobrecarregado",
                     "EncumbranceBaseTooltip": "Sobrecarregado Base: {base} (Strength)",
-                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})"
+                    "EncumbranceModifierTooltip": "{type} Bonus: {mod} ({source})",
+                    "ItemsAndUPBs": "Items and UPBs"
                 },
                 "Interface": {
                     "AmountToTransferInfo": "Minimo 1, maximo {max}",

--- a/static/templates/actors/parts/actor-inventory.hbs
+++ b/static/templates/actors/parts/actor-inventory.hbs
@@ -58,7 +58,7 @@
 
 {{#if (or isCharacter isDrone) }}
 {{#with system.encumbrance}}
-<div class="encumbrance {{#if encumbered}}encumbered{{/if}}" data-tooltip="<strong>{{ localize "SFRPG.ActorSheet.Inventory.Encumbrance.Encumbrance" }}</strong><br/>@attributes.encumbrance.max<br/><br/>{{#each tooltip as |tip|}}{{tip}}<br/>{{/each}}">
+<div class="encumbrance {{#if encumbered}}encumbered{{/if}}" data-tooltip="<strong>{{ localize "SFRPG.ActorSheet.Inventory.Encumbrance.Encumbrance" }}</strong> <small>({{ localize "SFRPG.ActorSheet.Inventory.Encumbrance.ItemsAndUPBs" }})</small><br/>@attributes.encumbrance.max<br/><br/>{{#each tooltip as |tip|}}{{tip}}<br/>{{/each}}">
     <span class="encumbrance-bar" style="width:{{pct}}%"></span>
     <span class="encumbrance-label">{{value}} / {{max}}</span>
     <div class="encumbrance-breakpoint arrow-up"></div>


### PR DESCRIPTION
Resolves #568 

Calculates the weight of UPBs when determining carried bulk/encumbrance, and adds info to the encumbrance tooltip to indicate both items and UPBs are accounted for, to prevent confusion.