### PR TITLE
Fix a deepClone/dataModels bug where the system overwrites all items

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -944,16 +944,13 @@ export class ItemSFRPG extends Mix(foundry.documents.Item).with(ItemActivationMi
             rollOptions.actionTargetSource = SFRPG.actionTargets;
         }
 
-        // Define Roll Data
-        const rollData = foundry.utils.deepClone(actorData);
-        // Add hasSave to roll
+        // Add has__ properties to itemData
         itemData.hasSave = this.hasSave;
         itemData.hasSkill = this.hasSkill;
         itemData.hasArea = this.hasArea;
         itemData.hasDamage = this.hasDamage;
         itemData.hasCapacity = this.hasCapacity();
 
-        rollData.item = itemData;
         const title = game.settings.get('sfrpg', 'useCustomChatCards') ? game.i18n.format("SFRPG.Rolls.AttackRoll") : game.i18n.format("SFRPG.Rolls.AttackRollFull", {name: this.name});
 
         // Warn the user if there is no ammo left
@@ -1382,12 +1379,6 @@ export class ItemSFRPG extends Mix(foundry.documents.Item).with(ItemActivationMi
             return 0;
         }, 0);
 
-        // Define Roll Data
-        const rollData = foundry.utils.mergeObject(foundry.utils.deepClone(actorData), {
-            item: itemData,
-            mod: actorData.abilities[abl].mod
-        });
-
         let title = '';
         if (game.settings.get('sfrpg', 'useCustomChatCards')) {
             if (isHealing) {
@@ -1403,7 +1394,7 @@ export class ItemSFRPG extends Mix(foundry.documents.Item).with(ItemActivationMi
             }
         }
 
-        const rollContext = RollContext.createItemRollContext(this, this.actor, {itemData: itemData, ownerData: rollData});
+        const rollContext = RollContext.createItemRollContext(this, this.actor, {itemData: itemData});
 
         /** Create additional modifiers. */
         const additionalModifiers = [];


### PR DESCRIPTION
This fixes an issue that was causing all items to be overwritten with the data of an item when an attack or damage was rolled with that item.

Original sheet:
<img width="890" height="427" alt="image" src="https://github.com/user-attachments/assets/1311e78d-65c5-44d5-8f42-8b3277212193" />

Sheet after rolling an attack and advancing the combat turn:
<img width="912" height="427" alt="image" src="https://github.com/user-attachments/assets/bd36a0e9-af87-4ccf-adbd-8dbed3403f39" />

It was caused by the implementation of a Data Model for actors causing the `deepClone()`-ing of their system data to stop functioning correctly. A pass was made to remove these instances previously, but two were missed. The solution was to remove these two instances. Fortunately, the functionality these lines originally performed looks to have been made obsolete a while ago, so they could be removed easily without affecting functionality (as far as I can tell).