### PR TITLE
Add data model support for feature macros

### DIFF
--- a/src/module/data/item/feat.mjs
+++ b/src/module/data/item/feat.mjs
@@ -104,6 +104,20 @@ export default class SFRPGItemFeat extends SFRPGItemBase {
             })
         });
 
+        // Add fields needed to existing base item fields
+        foundry.utils.mergeObject(schema.activation.fields, {
+            macroAfterActivate: new fields.DocumentUUIDField({
+                initial: null,
+                nullable: true,
+                label: "SFRPG.Items.Feat.FeatureMacroAfterActivate"
+            }),
+            macroAfterDeactivate: new fields.DocumentUUIDField({
+                initial: null,
+                nullable: true,
+                label: "SFRPG.Items.Feat.FeatureMacroAfterDeactivate"
+            })
+        });
+
         // No initial value changes to templated fields
 
         return schema;


### PR DESCRIPTION
Adds data model support for #1661 .
Initially I missed this as the PR hadn't had dev merged into it before I did final testing; need to remember to do that after major changes are made.