### PR TITLE
Hotfixes for 0.29.1 bugs

### DIFF
--- a/changelist.md
+++ b/changelist.md
@@ -1,3 +1,14 @@
+# 0.29.1.1
+This is a hotfix release to resolve a couple of small bugs.
+
+## Bugfixes
+
+- The value `@item.properties.operative` and other properties, if not present in item data, should now resolve to `0` in formulas
+  - This fixes weapon specialization not calculating damage bonuses correctly
+- Scaling cantip data settings are restored to spells that use them
+  - If you have the spells Energy Ray, Hazard, Injury Echo, or Telekinetic Projectile, you'll need to delete them and re-add from the compendiums
+- AC bonuses from armor and armor-bonus-granting modifiers now stack correctly, with only the highest value used
+
 # 0.29.1
 This release cleans up some more things on the backend and adds a couple of new features and bugfixes that were enabled by the implementation of the system data model in 0.29.0. Thanks to @levirak, @danimrath, and @ian612 for their contributions to this release, and to the community for filing bug reports and feature requests!
 

--- a/src/items/alien-archives/aanung-an.json
+++ b/src/items/alien-archives/aanung-an.json
@@ -1038,6 +1038,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": false,
+          "d6": true
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/alien-archives/kathrepi_shade.json
+++ b/src/items/alien-archives/kathrepi_shade.json
@@ -1019,6 +1019,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": false,
+          "d6": true
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/alien-archives/morlamaw.json
+++ b/src/items/alien-archives/morlamaw.json
@@ -936,6 +936,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": false,
+          "d6": true
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/alien-archives/planar_scion_ganzi.json
+++ b/src/items/alien-archives/planar_scion_ganzi.json
@@ -2095,6 +2095,10 @@
           "dc": "15",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/alien-archives/planar_scion_prismeni.json
+++ b/src/items/alien-archives/planar_scion_prismeni.json
@@ -1807,6 +1807,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "con",
         "skillCheck": {
           "type": "",

--- a/src/items/alien-archives/security_specialist.json
+++ b/src/items/alien-archives/security_specialist.json
@@ -1657,6 +1657,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "con",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/keskodai_l1.json
+++ b/src/items/characters/keskodai_l1.json
@@ -2497,6 +2497,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": false,
+          "d6": true
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/keskodai_l4.json
+++ b/src/items/characters/keskodai_l4.json
@@ -3033,6 +3033,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": false,
+          "d6": true
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/keskodai_l8.json
+++ b/src/items/characters/keskodai_l8.json
@@ -6594,6 +6594,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": false,
+          "d6": true
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/raia_l1.json
+++ b/src/items/characters/raia_l1.json
@@ -2002,6 +2002,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "con",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/raia_l4.json
+++ b/src/items/characters/raia_l4.json
@@ -4100,6 +4100,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "con",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/raia_l8.json
+++ b/src/items/characters/raia_l8.json
@@ -4894,6 +4894,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "con",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/zemir_l1.json
+++ b/src/items/characters/zemir_l1.json
@@ -2200,6 +2200,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/zemir_l4.json
+++ b/src/items/characters/zemir_l4.json
@@ -3380,6 +3380,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/characters/zemir_l8.json
+++ b/src/items/characters/zemir_l8.json
@@ -4056,6 +4056,10 @@
           "dc": "",
           "descriptor": "negate"
         },
+        "scaling": {
+          "d3": true,
+          "d6": false
+        },
         "school": "evo",
         "skillCheck": {
           "type": "",

--- a/src/items/spells/energy_ray.json
+++ b/src/items/spells/energy_ray.json
@@ -154,6 +154,10 @@
       "dc": "",
       "descriptor": "negate"
     },
+    "scaling": {
+      "d3": true,
+      "d6": false
+    },
     "school": "con",
     "skillCheck": {
       "type": "",

--- a/src/items/spells/hazard.json
+++ b/src/items/spells/hazard.json
@@ -171,6 +171,10 @@
       "dc": "",
       "descriptor": "negate"
     },
+    "scaling": {
+      "d3": true,
+      "d6": false
+    },
     "school": "evo",
     "skillCheck": {
       "type": "",

--- a/src/items/spells/injury_echo.json
+++ b/src/items/spells/injury_echo.json
@@ -133,6 +133,10 @@
       "dc": "",
       "descriptor": "negate"
     },
+    "scaling": {
+      "d3": false,
+      "d6": true
+    },
     "school": "trs",
     "skillCheck": {
       "type": "",

--- a/src/items/spells/telekinetic_projectile.json
+++ b/src/items/spells/telekinetic_projectile.json
@@ -95,6 +95,10 @@
       "dc": "",
       "descriptor": "negate"
     },
+    "scaling": {
+      "d3": false,
+      "d6": true
+    },
     "school": "evo",
     "skillCheck": {
       "type": "",

--- a/src/module/data/item/spell.mjs
+++ b/src/module/data/item/spell.mjs
@@ -101,6 +101,16 @@ export default class SFRPGItemSpell extends SFRPGItemBase {
                     label: "SFRPG.Items.Spell.Prepared"
                 })
             }),
+            scaling: new fields.SchemaField({
+                d3: new fields.BooleanField({
+                    initial: false,
+                    required: true
+                }),
+                d6: new fields.BooleanField({
+                    initial: false,
+                    required: true
+                })
+            }),
             school: new fields.StringField({
                 initial: "abj",
                 required: true,

--- a/src/module/rolls/roll.js
+++ b/src/module/rolls/roll.js
@@ -197,9 +197,9 @@ export default class SFRPGRoll extends Roll {
         }
     }
 
-    static replaceFormulaData(formula, data, {missing, warn = false} = {}) {
+    static replaceFormulaData(formula, data, options = {missing: 0, warn: true}) {
         formula = SFRPGRoll._insertValueProperty(formula, data);
-        return super.replaceFormulaData(formula, data, {missing, warn = false} = {});
+        return super.replaceFormulaData(formula, data, options);
     }
 
     /**

--- a/src/module/rules/actions/actor/character/calculate-base-armor-class.js
+++ b/src/module/rules/actions/actor/character/calculate-base-armor-class.js
@@ -141,11 +141,17 @@ export default function(engine) {
             eac.maxDex = maxDex;
             kac.maxDex = maxDex;
 
-            if (armorEac.armor) eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorEac.value.signedString(), name: armorEac.name }));
+            if (armorEac.armor) {
+                eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorEac.value.signedString(), name: armorEac.name }));
+                eac.armorInfo = {bonus: armorEac.value, tooltip: game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorEac.value.signedString(), name: armorEac.name })}; // for checking if an armor modifier is higher than the armor bonus
+            }
             if (shields) shields.forEach(shield => eac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: (shield.system.bonus.wielded || 0).signedString(), name: shield.name })));
             eac.tooltip.push(maxDexTooltip);
 
-            if (armorKac.armor) kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorKac.value.signedString(), name: armorKac.name }));
+            if (armorKac.armor) {
+                kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorKac.value.signedString(), name: armorKac.name }));
+                kac.armorInfo = {bonus: armorKac.value, tooltip: game.i18n.format("SFRPG.ACTooltipArmorACMod", { armor: armorKac.value.signedString(), name: armorKac.name })};// for checking if an armor modifier is higher than the armor bonus
+            }
             if (shields) shields.forEach(shield => kac.tooltip.push(game.i18n.format("SFRPG.ACTooltipShieldACMod", { shield: (shield.system.bonus.wielded || 0).signedString(), name: shield.name })));
             kac.tooltip.push(maxDexTooltip);
         } else {


### PR DESCRIPTION
Fixes issues with weapon specialization calculating operative property incorrectly, which broke weapon specialization, and with broken cantrip scaling.
Also resolves #1705, ensuring the correct calculation of armor bonuses.