### PR TITLE
Item Saving Throw Bonuses

### DIFF
--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -311,10 +311,10 @@ export class ItemSheetSFRPG extends foundry.appv1.sheets.ItemSheet {
     _computeItemSaveBonus() {
         // TODO: Move this into the item's calculation rather than calculating on the sheet
         const parentItem = this.item;
-        const parentActorAbilities = parentItem.actor?.system?.abilities;
+        const parentActorAbilities = parentItem.actor?.system?.attributes;
         const itemLevel = parentItem.system.level;
         if (parentActorAbilities) {
-            return `[F: ${Math.max(itemLevel, parentActorAbilities.con.mod, 0)}, R: ${Math.max(itemLevel, parentActorAbilities.dex.mod, 0)}, W: ${Math.max(itemLevel, parentActorAbilities.dex.mod, 0)}]`;
+            return `[F: ${Math.max(itemLevel, parentActorAbilities.fort.bonus, 0)}, R: ${Math.max(itemLevel, parentActorAbilities.reflex.bonus, 0)}, W: ${Math.max(itemLevel, parentActorAbilities.will.bonus, 0)}]`;
         } else if (itemLevel < 1) {
             return 0;
         } else {


### PR DESCRIPTION
#1715 
Item Saving Throw Bonuses are not being calculated properly.

Core Rules pg 409 
"An object’s total saving throw bonus for Fortitude, Reflex, and Will saves is equal to the object’s caster level or item level. An object that is held or worn uses the saving throw bonus of the creature carrying it if that bonus is better than its own saving throw bonus. Items with a caster level or item level of 0 don’t receive saving throws when unattended."