### PR TITLE
Avoid error on no descriptor (Ship damage rolls)

### DIFF
--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -588,8 +588,10 @@ export class DiceSFRPG {
 
                 // Add descriptors
                 const descriptors = itemContext.entity.system.descriptors;
-                for (const [descriptor, isEnabled] of Object.entries(descriptors)) {
-                    if (isEnabled) tags.push({tag: descriptor, text: SFRPG.descriptors[descriptor]});
+                if (descriptors) {
+                    for (const [descriptor, isEnabled] of Object.entries(descriptors)) {
+                        if (isEnabled) tags.push({tag: descriptor, text: SFRPG.descriptors[descriptor]});
+                    }
                 }
 
                 // Add special materials


### PR DESCRIPTION
When rolling from a ship damage chat card the code crashes when it tries to add descriptors that do not exist.