### PR TITLE
Update to take from correct token image location.

### DIFF
--- a/src/module/chat/chatbox.js
+++ b/src/module/chat/chatbox.js
@@ -64,7 +64,7 @@ export default class SFRPGCustomChatMessage {
             rollType: data.rollType,
             rollNotes: data.htmlData?.find(x => x.name === "rollNotes")?.value,
             type: CONST.CHAT_MESSAGE_STYLES.OTHER,
-            tokenImg: actor.token?.img || actor.img,
+            tokenImg: actor.token?.texture?.src || actor.img,
             actorId: actor.id,
             tokenId: this.getToken(actor),
             breakdown: data.breakdown,
@@ -83,7 +83,7 @@ export default class SFRPGCustomChatMessage {
             if (speaker.token) {
                 const token = game.scenes.get(speaker.scene)?.tokens?.get(speaker.token);
                 if (token) {
-                    options.tokenImg = token.img;
+                    options.tokenImg = token.texture?.src;
                     setImage = true;
                 }
             }


### PR DESCRIPTION
Correctly pull from the token image for chat cards. Currently only works when it defaults to the actor.img.