### PR TITLE
Issue 1567 Track expanded state on documents and items

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1087,16 +1087,17 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
 
         if (item.expanded || false) {
             const summary = li.children('.item-summary');
+            li.removeClass('expanded');
+            item.expanded = false;
             summary.slideUp(200, () => {
-                li.removeClass('expanded');
-                item.expanded = false;
                 item.setFlag('sfrpg', 'expanded', false);
             });
         } else {
             const summary = await this._prepareItemSummary(item);
+            li.append(summary.hide());
+            li.addClass('expanded');
+            item.expanded = true;
             summary.slideDown(200, () => {
-                li.addClass('expanded');
-                item.expanded = true;
                 item.setFlag('sfrpg', 'expanded', true);
             });
         }

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -168,7 +168,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
                 const desiredDescription = chatData.description.short || chatData.description.value;
                 const div = $(`<div class="item-summary">${desiredDescription}</div>`);
                 const props = $(`<div class="item-properties"></div>`);
-                chatData.properties.forEach(p => {
+                chatData.chatProperties.forEach(p => {
                     let tooltipValue = p.tooltip || p.title || "";
                     if (tooltipValue) tooltipValue = `data-tooltip="${tooltipValue}"`;
                     props.append(

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -93,10 +93,6 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
         data.labels = this.actor.labels || {};
         data.filters = this._filters;
 
-        for (const item of data.items) {
-            item.expanded = item.getFlag('sfrpg', 'expanded') || false;
-        }
-
         if (!data.system?.details?.biography?.fullBodyImage) {
             this.actor.system = foundry.utils.mergeObject(this.actor.system, {
                 details: {
@@ -169,22 +165,10 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
 
         this._prepareItems(data);
 
-        // Prepare summary HTML for expanded items
         for (const item of data.items) {
+            item.expanded = item.getFlag('sfrpg', 'expanded') || false;
             if (item.expanded) {
-                const chatData = await item.getChatData();
-                const desiredDescription = chatData.description.short || chatData.description.value;
-                const div = $(`<div class="item-summary">${desiredDescription}</div>`);
-                const props = $(`<div class="item-properties"></div>`);
-                chatData.chatProperties.forEach(p => {
-                    let tooltipValue = p.tooltip || p.title || "";
-                    if (tooltipValue) tooltipValue = `data-tooltip="${tooltipValue}"`;
-                    props.append(
-                        `<span class="tag" ${tooltipValue}><strong>${p.title ? p.title + ":" : ""} </strong>${p.name}</span>`
-                    );
-                });
-                div.append(props);
-                item.summaryHTML = div[0].outerHTML;
+                await this._prepareItemSummary(item);
             }
         }
 
@@ -201,7 +185,6 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             secrets
         });
 
-        this.data = data;
         return data;
     }
 
@@ -239,7 +222,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
         html.find('.item').each((i, el) => {
             const li = $(el);
             const itemId = li.data('item-id');
-            const item = this.data.items.find(x => x.id === itemId);
+            const item = this.actor.items.find(x => x.id === itemId);
             if (item && item.expanded) {
                 li.addClass('expanded');
                 li.append(item.summaryHTML);
@@ -438,6 +421,27 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
                 break;
         }
         app?.render(true);
+    }
+
+    /**
+     * Prepares drop-down summary HTML for expanded items on character sheets
+     * @param {ItemSFRPG} item      An item to prepare the summary for
+     */
+    async _prepareItemSummary(item) {
+        const chatData = await item.getChatData();
+        const desiredDescription = chatData.description.short || chatData.description.value;
+        const div = $(`<div class="item-summary">${desiredDescription}</div>`);
+        const props = $(`<div class="item-properties"></div>`);
+        chatData.chatProperties.forEach(p => {
+            let tooltipValue = p.tooltip || p.title || "";
+            if (tooltipValue) tooltipValue = `data-tooltip="${tooltipValue}"`;
+            props.append(
+                `<span class="tag" ${tooltipValue}><strong>${p.title ? p.title + ":" : ""} </strong>${p.name}</span>`
+            );
+        });
+        div.append(props);
+        item.summaryHTML = div[0].outerHTML;
+        return div;
     }
 
     _prepareTraits(traits) {
@@ -1076,32 +1080,15 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
         event.preventDefault();
         const li = $(event.currentTarget).parents('.item');
         const item = this.actor.items.get(li.data('item-id'));
-        const isExpanded = item.expanded || false;
 
-        if (isExpanded) {
+        if (item.expanded || false) {
             const summary = li.children('.item-summary');
             summary.slideUp(200, () => summary.remove());
             li.removeClass('expanded');
             item.expanded = false;
         } else {
-            const chatData = await item.getChatData();
-            const desiredDescription = chatData.description.short || chatData.description.value;
-            const div = $(`<div class="item-summary">${desiredDescription}</div>`);
-            Hooks.callAll("renderItemSummary", this, div, {}); // Event listeners need to be added to this HTML.
-
-            const props = $(`<div class="item-properties"></div>`);
-            chatData.chatProperties.forEach(p => {
-                let tooltipValue = p.tooltip || p.title || "";
-                if (tooltipValue) tooltipValue = `data-tooltip="${tooltipValue}"`;
-                props.append(
-                    `<span class="tag" ${tooltipValue}><strong>${p.title ? p.title + ":" : ""} </strong>${p.name}</span>`
-                );
-            });
-
-            div.append(props);
-            li.append(div.hide());
-
-            div.slideDown(200, function() { /* noop */ });
+            const summary = await this._prepareItemSummary(item);
+            summary.slideDown(200, () => summary.show());
             li.addClass('expanded');
             item.expanded = true;
         }

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -58,6 +58,14 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
         });
     }
 
+    /** @inheritdoc */
+    async close(options) {
+        for (const item of this.actor.items) {
+            item.setFlag('sfrpg', 'expanded', false);
+        }
+        return super.close(options);
+    }
+
     /**
      * Add some extra data when rendering the sheet to reduce the amount of logic required within the template.
      */
@@ -1060,7 +1068,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
     }
 
     /**
-     * Handle rolling of an item form the Actor sheet, obtaining the item instance an dispatching to it's roll method.
+     * Handle creation and display of a short summary for an item when it is clicked on in the character sheet
      *
      * @param {Event} event The html event
      */

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -441,6 +441,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
         });
         div.append(props);
         item.summaryHTML = div[0].outerHTML;
+        Hooks.callAll("renderItemSummary", this, div, {}); // Event listeners need to be added to this HTML.
         return div;
     }
 

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -60,8 +60,11 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
 
     /** @inheritdoc */
     async close(options) {
-        for (const item of this.actor.items) {
-            item.setFlag('sfrpg', 'expanded', false);
+        const closeAllSetting = game.settings.get("sfrpg", "closeAllItemSummaries");
+        if (closeAllSetting) {
+            for (const item of this.actor.items) {
+                item.setFlag('sfrpg', 'expanded', false);
+            }
         }
         return super.close(options);
     }

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1087,17 +1087,19 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
 
         if (item.expanded || false) {
             const summary = li.children('.item-summary');
-            summary.slideUp(200, () => summary.remove());
-            li.removeClass('expanded');
-            item.expanded = false;
+            summary.slideUp(200, () => {
+                li.removeClass('expanded');
+                item.expanded = false;
+                item.setFlag('sfrpg', 'expanded', false);
+            });
         } else {
             const summary = await this._prepareItemSummary(item);
-            summary.slideDown(200, () => summary.show());
-            li.addClass('expanded');
-            item.expanded = true;
+            summary.slideDown(200, () => {
+                li.addClass('expanded');
+                item.expanded = true;
+                item.setFlag('sfrpg', 'expanded', true);
+            });
         }
-
-        await item.setFlag('sfrpg', 'expanded', item.expanded);
     }
 
     async _onItemSplit(event) {

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -62,11 +62,18 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
     async close(options) {
         const closeAllSetting = game.settings.get("sfrpg", "closeAllItemSummaries");
         if (closeAllSetting) {
-            for (const item of this.actor.items) {
-                item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
-            }
+            await this._closeAllItemSummaries();
         }
         return super.close(options);
+    }
+
+    /**
+     * Close all expanded item summaries for the current user.
+     */
+    async _closeAllItemSummaries() {
+        for (const item of this.actor.items) {
+            item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
+        }
     }
 
     /**

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -63,7 +63,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
         const closeAllSetting = game.settings.get("sfrpg", "closeAllItemSummaries");
         if (closeAllSetting) {
             for (const item of this.actor.items) {
-                item.setFlag('sfrpg', 'expanded', false);
+                item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
             }
         }
         return super.close(options);
@@ -169,7 +169,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
         this._prepareItems(data);
 
         for (const item of data.items) {
-            item.expanded = item.getFlag('sfrpg', 'expanded') || false;
+            item.expanded = item.getFlag('sfrpg', `expanded.${game.user.id}`) || false;
             if (item.expanded) {
                 await this._prepareItemSummary(item);
             }
@@ -1090,7 +1090,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             li.removeClass('expanded');
             item.expanded = false;
             summary.slideUp(200, () => {
-                item.setFlag('sfrpg', 'expanded', false);
+                item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
             });
         } else {
             const summary = await this._prepareItemSummary(item);
@@ -1098,7 +1098,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             li.addClass('expanded');
             item.expanded = true;
             summary.slideDown(200, () => {
-                item.setFlag('sfrpg', 'expanded', true);
+                item.setFlag('sfrpg', `expanded.${game.user.id}`, true);
             });
         }
     }

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -139,7 +139,7 @@ export class ItemCollectionSheet extends DocumentSheet {
                 const chatData = await this.getChatData(item, { secrets: true, rollData: item });
                 const div = $(`<div class="item-summary">${chatData.system.description.value}</div>`);
                 const props = $(`<div class="item-properties"></div>`);
-                chatData.properties.forEach(p => props.append(`<span class="tag" ${ p.tooltip ? ("data-tooltip='" + p.tooltip + "'") : ""}>${p.name}</span>`));
+                chatData.chatProperties.forEach(p => props.append(`<span class="tag" ${ p.tooltip ? ("data-tooltip='" + p.tooltip + "'") : ""}>${p.name}</span>`));
                 div.append(props);
                 item.summaryHTML = div[0].outerHTML;
             }

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -79,7 +79,7 @@ export class ItemCollectionSheet extends DocumentSheet {
     /**
      * Add some extra data when rendering the sheet to reduce the amount of logic required within the template.
      */
-    async getData() {
+    getData() {
         const data = super.getData();
         data.isCharacter = true;
         data.isOwner = game.user.isGM;
@@ -111,8 +111,6 @@ export class ItemCollectionSheet extends DocumentSheet {
             item.totalWeight = item.totalWeight < 1 && item.totalWeight > 0
                 ? "L"
                 : item.totalWeight === 0 ? "-" : Math.floor(item.totalWeight);
-
-            item.expanded = item.expanded || false;
         }
 
         data.items = [];
@@ -132,26 +130,12 @@ export class ItemCollectionSheet extends DocumentSheet {
             }
         }
 
-        // Prepare summary HTML for expanded items
-        for (const itemData of data.items) {
-            const item = itemData.item;
-            if (item.expanded) {
-                const chatData = await this.getChatData(item, { secrets: true, rollData: item });
-                const div = $(`<div class="item-summary">${chatData.system.description.value}</div>`);
-                const props = $(`<div class="item-properties"></div>`);
-                chatData.chatProperties.forEach(p => props.append(`<span class="tag" ${ p.tooltip ? ("data-tooltip='" + p.tooltip + "'") : ""}>${p.name}</span>`));
-                div.append(props);
-                item.summaryHTML = div[0].outerHTML;
-            }
-        }
-
         data.itemCollection = tokenData;
 
         if (data.itemCollection.locked && !game.user.isGM) {
             this.close();
         }
 
-        this.data = data;
         return data;
     }
 
@@ -207,15 +191,12 @@ export class ItemCollectionSheet extends DocumentSheet {
         const li = $(event.currentTarget).parents('.item');
         const itemId = li.attr("data-item-id");
         const item = this.itemCollection.flags.sfrpg.itemCollection.items.find(x => x._id === itemId);
-        const isExpanded = item.expanded || false;
+        const chatData = await this.getChatData(item, { secrets: true, rollData: item });
 
-        if (isExpanded) {
+        if (li.hasClass('expanded')) {
             const summary = li.children('.item-summary');
             summary.slideUp(200, () => summary.remove());
-            li.removeClass('expanded');
-            item.expanded = false;
         } else {
-            const chatData = await this.getChatData(item, { secrets: true, rollData: item });
             const div = $(`<div class="item-summary">${chatData.system.description.value}</div>`);
             Hooks.callAll("renderItemSummary", this, div, {}); // Event listeners need to be added to newly added HTML.
             const props = $(`<div class="item-properties"></div>`);
@@ -224,15 +205,8 @@ export class ItemCollectionSheet extends DocumentSheet {
             div.append(props);
             li.append(div.hide());
             div.slideDown(200, function() { /* noop */ });
-            li.addClass('expanded');
-            item.expanded = true;
         }
-
-        // Update the item in the collection
-        const newItems = [...this.itemCollection.flags.sfrpg.itemCollection.items];
-        const index = newItems.findIndex(x => x._id === itemId);
-        newItems[index] = item;
-        await this.itemCollection.update({"flags.sfrpg.itemCollection.items": newItems});
+        li.toggleClass('expanded');
     }
 
     _onItemEdit(event) {

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -111,8 +111,6 @@ export class ItemCollectionSheet extends DocumentSheet {
             item.totalWeight = item.totalWeight < 1 && item.totalWeight > 0
                 ? "L"
                 : item.totalWeight === 0 ? "-" : Math.floor(item.totalWeight);
-
-            item.expanded = item.expanded || false;
         }
 
         data.items = [];
@@ -132,26 +130,12 @@ export class ItemCollectionSheet extends DocumentSheet {
             }
         }
 
-        // Prepare summary HTML for expanded items
-        for (const itemData of data.items) {
-            const item = itemData.item;
-            if (item.expanded) {
-                const chatData = await this.getChatData(item, { secrets: true, rollData: item });
-                const div = $(`<div class="item-summary">${chatData.system.description.value}</div>`);
-                const props = $(`<div class="item-properties"></div>`);
-                chatData.chatProperties.forEach(p => props.append(`<span class="tag" ${ p.tooltip ? ("data-tooltip='" + p.tooltip + "'") : ""}>${p.name}</span>`));
-                div.append(props);
-                item.summaryHTML = div[0].outerHTML;
-            }
-        }
-
         data.itemCollection = tokenData;
 
         if (data.itemCollection.locked && !game.user.isGM) {
             this.close();
         }
 
-        this.data = data;
         return data;
     }
 
@@ -207,15 +191,12 @@ export class ItemCollectionSheet extends DocumentSheet {
         const li = $(event.currentTarget).parents('.item');
         const itemId = li.attr("data-item-id");
         const item = this.itemCollection.flags.sfrpg.itemCollection.items.find(x => x._id === itemId);
-        const isExpanded = item.expanded || false;
+        const chatData = await this.getChatData(item, { secrets: true, rollData: item });
 
-        if (isExpanded) {
+        if (li.hasClass('expanded')) {
             const summary = li.children('.item-summary');
             summary.slideUp(200, () => summary.remove());
-            li.removeClass('expanded');
-            item.expanded = false;
         } else {
-            const chatData = await this.getChatData(item, { secrets: true, rollData: item });
             const div = $(`<div class="item-summary">${chatData.system.description.value}</div>`);
             Hooks.callAll("renderItemSummary", this, div, {}); // Event listeners need to be added to newly added HTML.
             const props = $(`<div class="item-properties"></div>`);
@@ -224,15 +205,8 @@ export class ItemCollectionSheet extends DocumentSheet {
             div.append(props);
             li.append(div.hide());
             div.slideDown(200, function() { /* noop */ });
-            li.addClass('expanded');
-            item.expanded = true;
         }
-
-        // Update the item in the collection
-        const newItems = [...this.itemCollection.flags.sfrpg.itemCollection.items];
-        const index = newItems.findIndex(x => x._id === itemId);
-        newItems[index] = item;
-        await this.itemCollection.update({"flags.sfrpg.itemCollection.items": newItems});
+        li.toggleClass('expanded');
     }
 
     _onItemEdit(event) {

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -347,7 +347,7 @@ export class ItemCollectionSheet extends DocumentSheet {
         }
 
         // Filter properties and return
-        data.properties = props.filter(p => !!p.value && !!p.name);
+        data.chatProperties = props.filter(p => !!p.value && !!p.name);
         return data;
     }
 

--- a/src/module/system/settings.js
+++ b/src/module/system/settings.js
@@ -350,4 +350,13 @@ export const registerSystemSettings = function() {
             });
         }
     });
+
+    game.settings.register("sfrpg", "closeAllItemSummaries", {
+        name: "SFRPG.Settings.CloseAllItemSummaries.Name",
+        hint: "SFRPG.Settings.CloseAllItemSummaries.Hint",
+        scope: "user",
+        config: true,
+        default: true,
+        type: Boolean
+    });
 };

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -733,7 +733,7 @@ Hooks.once("ready", async () => {
 });
 
 export function registerKeybinds() {
-    const { SHIFT, CONTROL, ALT } = foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS;
+    const { SHIFT, CONTROL } = foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS;
 
     game.keybindings.register('sfrpg', 'summaries', {
         name: game.i18n.localize('SFRPG.Keybindings.CloseAllItemSummaries.Name'),
@@ -752,7 +752,7 @@ export function registerKeybinds() {
             return true;
         },
         restricted: false,
-        precedence: CONST.KEYBINDING_PRECEDENCE.PRIORITY,
+        precedence: CONST.KEYBINDING_PRECEDENCE.PRIORITY
     });
 }
 

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -503,6 +503,8 @@ Hooks.once('init', async function() {
         });
     }
 
+    registerKeybinds();
+
     const finishTime = (new Date()).getTime();
     console.log(`Starfinder | [INIT] Done (operation took ${finishTime - initTime} ms)`);
 });
@@ -729,6 +731,30 @@ Hooks.once("ready", async () => {
     const startupDuration = finishTime - initTime;
     console.log(`Starfinder | [STARTUP] Total launch took ${Number(startupDuration / 1000).toFixed(2)} seconds.`);
 });
+
+export function registerKeybinds() {
+    const { SHIFT, CONTROL, ALT } = foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS;
+
+    game.keybindings.register('sfrpg', 'summaries', {
+        name: game.i18n.localize('SFRPG.Keybindings.CloseAllItemSummaries.Name'),
+        hint: game.i18n.localize('SFRPG.Keybindings.CloseAllItemSummaries.Hint'),
+        editable: [
+            {
+                key: 'KeyC',
+                modifiers: [CONTROL, SHIFT]
+            }
+        ],
+        onDown: () => {
+            const app = Object.values(ui.windows).find(app => app instanceof ActorSheetSFRPG && app.actor);
+            if (app) {
+                app._closeAllItemSummaries();
+            }
+            return true;
+        },
+        restricted: false,
+        precedence: CONST.KEYBINDING_PRECEDENCE.PRIORITY,
+    });
+}
 
 /**
  * Migrates containers from an old format (not sure what version) to a modern version.

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2440,6 +2440,10 @@
                 "Hint": "How long (in MS) to display chat notifications before they are dismissed (Default 5000).",
                 "Name": "Chat Notification Duration"
             },
+            "CloseAllItemSummaries": {
+                "Hint": "Close all item summaries automatically when an actor sheet is closed.",
+                "Name": "Automatically Close Item Summaries"
+            },
             "CombatCards": {
                 "NormalHint": "Change which combat chat cards should be displayed during normal combat.",
                 "NormalName": "Normal combat",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -887,6 +887,12 @@
         },
         "Disabled": "Disabled",
         "DistAny": "Any",
+        "Keybindings": {
+            "CloseAllItemSummaries": {
+                "Hint": "Closes all opened item summaries on the character sheet.",
+                "Name": "Close All Item Summaries"
+            }
+        },
         "DroneSheet": {
             "Chassis": {
                 "Details": {


### PR DESCRIPTION
These changes make it so whenever a sheet re-renders even after being closed it persists the expanded state of the documents/items.

Resolves #1567 

This Change also includes adding a new setting to have all item summaries close when a sheet is closed or to remember the closed/open state.

To add to that a new keybinding can be found in the controls section that defaults to CTRL+SHIFT+C that closes all open summaries on an active actor sheet.