### PR TITLE
Fix chat data properties overwriting item properties

### DIFF
--- a/changelist.md
+++ b/changelist.md
@@ -1,3 +1,15 @@
+# Development
+Changes made to the most recent dev version
+
+## Breaking Changes
+
+- `item.getChatData()` returns chat properties as `chatProperties` rather than `properties`, which is where they're now spaced in chat message card .hbs files
+
+## Bugfixes
+
+- Item cards display properties in the footer of the card correctly now
+- Item summaries displayed on actor sheets no longer break item properties by overriding them
+
 # 0.30.0 - Targets Everywhere!
 This new system version adds new features to Starfinder 1e supporting Foundry's "targeting" system, including evaluation of rolls against targets and success/failure/hit/miss display for attack rolls, checks, and saves.
 

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1044,7 +1044,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             Hooks.callAll("renderItemSummary", this, div, {}); // Event listeners need to be added to this HTML.
 
             const props = $(`<div class="item-properties"></div>`);
-            chatData.properties.forEach(p => {
+            chatData.chatProperties.forEach(p => {
                 let tooltipValue = p.tooltip || p.title || "";
                 if (tooltipValue) tooltipValue = `data-tooltip="${tooltipValue}"`;
                 props.append(

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -200,7 +200,7 @@ export class ItemCollectionSheet extends DocumentSheet {
             const div = $(`<div class="item-summary">${chatData.system.description.value}</div>`);
             Hooks.callAll("renderItemSummary", this, div, {}); // Event listeners need to be added to newly added HTML.
             const props = $(`<div class="item-properties"></div>`);
-            chatData.properties.forEach(p => props.append(`<span class="tag" ${ p.tooltip ? ("data-tooltip='" + p.tooltip + "'") : ""}>${p.name}</span>`));
+            chatData.chatProperties.forEach(p => props.append(`<span class="tag" ${ p.tooltip ? ("data-tooltip='" + p.tooltip + "'") : ""}>${p.name}</span>`));
 
             div.append(props);
             li.append(div.hide());

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -558,7 +558,7 @@ export class ItemSFRPG extends Mix(foundry.documents.Item).with(ItemActivationMi
         }
 
         // Filter properties and return
-        data.properties = props.filter(p => !!p?.name);
+        data.chatProperties = props.filter(p => !!p?.name);
         return data;
     }
 

--- a/static/templates/chat/consumable-card.hbs
+++ b/static/templates/chat/consumable-card.hbs
@@ -18,7 +18,7 @@
     </div>
 
     <footer class="card-footer">
-        {{#each system.properties}}
+        {{#each system.chatProperties}}
         <span>{{this.name}}</span>
         {{/each}}
     </footer>

--- a/static/templates/chat/consumed-item-card.hbs
+++ b/static/templates/chat/consumed-item-card.hbs
@@ -21,7 +21,7 @@
     </div>
 
     <footer class="card-footer">
-        {{#each system.properties}}
+        {{#each system.chatProperties}}
         <span>{{this.name}}</span>
         {{/each}}
     </footer>

--- a/static/templates/chat/item-action-card.hbs
+++ b/static/templates/chat/item-action-card.hbs
@@ -24,7 +24,7 @@
     </div>
 
     <footer class="card-footer">
-        {{#each system.properties}}
+        {{#each system.chatProperties}}
         <span>{{this}}</span>
         {{/each}}
         {{#if cost}}

--- a/static/templates/chat/item-card.hbs
+++ b/static/templates/chat/item-card.hbs
@@ -25,7 +25,7 @@
     </div>
 
     <footer class="card-footer">
-        {{#each system.properties}}
+        {{#each system.chatProperties}}
         <span data-tooltip="{{#if this.tooltip}}{{this.tooltip}}{{else}}{{this.title}}{{/if}}">{{#if this.title}}<strong>{{this.title}}: </strong>{{/if}}{{this.name}}</span>
         {{/each}}
     </footer>

--- a/static/templates/chat/weapon-card.hbs
+++ b/static/templates/chat/weapon-card.hbs
@@ -16,7 +16,7 @@
     </div>
 
     <footer class="card-footer">
-        {{#each system.properties}}
+        {{#each system.chatProperties}}
         <span>{{this}}</span>
         {{/each}}
     </footer>


### PR DESCRIPTION
This fixes an issue where the `item.getChatData()` method would overwrite an item's `properties`... property. Bug was introduced after removing instances of cloning system data objects (which itself no longer worked).