### PR TITLE
Add a system to display important update information to users

### DIFF
--- a/src/module/apps/update-notification.js
+++ b/src/module/apps/update-notification.js
@@ -2,7 +2,7 @@
  * A list of the notifications to display, as well as the system version associated with them
  */
 const updateNotifications = {
-    0.1: {
+    0.001: {
         version: "0.30.1",
         message: "To facilitate better communication between the system developers and users, we have added this notification system, starting in Version 0.30.1, which will display upon installing a new system version with significant changes to be aware of. If an update is minor, you may not see one of these messages.<br>As they will only show up upon installing a new system version and we don't have the ability to wait for localization for all languages before releasing system updates, these messages will unfortunately only be in English (apologies to international users!)."
     }

--- a/src/module/apps/update-notification.js
+++ b/src/module/apps/update-notification.js
@@ -1,0 +1,51 @@
+/**
+ * A list of the notifications to display, as well as the system version associated with them
+ */
+const updateNotifications = {
+    0.1: {
+        version: "0.30.1",
+        message: "To facilitate better communication between the system developers and users, we have added this notification system, starting in Version 0.30.1, which will display upon installing a new system version with significant changes to be aware of. If an update is minor, you may not see one of these messages.<br>As they will only show up upon installing a new system version and we don't have the ability to wait for localization for all languages before releasing system updates, these messages will unfortunately only be in English (apologies to international users!)."
+    }
+};
+
+/**
+ * Determines whether a notification dialog is necessary after a system update, and what should be displayed
+ */
+export async function updateNotification() {
+    // The current system version's notification schema number
+    const systemNotificationSchema = Math.max(...Object.keys(updateNotifications).map(Number));
+    // The current world's notification schema number
+    const worldSchema = game.settings.get("sfrpg", "notificationSchema");
+
+    if (systemNotificationSchema > worldSchema) {
+        // Get list of update versions and list of messages to display
+        const toDisplay = [];
+        for (const [schema, entry] of Object.entries(updateNotifications)) {
+            if (Number(schema) > worldSchema && Number(schema) <= systemNotificationSchema) {
+                toDisplay.push(entry);
+            }
+        }
+
+        // Construct message
+        let dlgText = "";
+        for (const notif of toDisplay) {
+            dlgText += `<h4>Version ${notif.version}</h4><p>${notif.message}</p>`;
+        }
+        dlgText += game.i18n.localize("SFRPG.Notification.Bugs");
+
+        // Display dialog box with the necessary update messages
+        const proceed = await foundry.applications.api.DialogV2.prompt({
+            window: {title: game.i18n.localize("SFRPG.Notification.Title")},
+            content: dlgText,
+            position: {width: 650},
+            ok: {
+                label: game.i18n.localize("SFRPG.Notification.Button")
+            }
+        });
+
+        // Update notification schema setting of the world
+        if (proceed === "ok") {
+            game.settings.set("sfrpg", "notificationSchema", systemNotificationSchema);
+        }
+    }
+}

--- a/src/module/system/settings.js
+++ b/src/module/system/settings.js
@@ -57,15 +57,6 @@ export const registerSystemSettings = function() {
         }
     });
 
-    game.settings.register("sfrpg", "worldSchemaVersion", {
-        name: "SFRPG.Settings.WorldSchemaVersion.Name",
-        hint: "SFRPG.Settings.WorldSchemaVersion.Hint",
-        scope: "world",
-        config: false,
-        default: 0,
-        type: Number
-    });
-
     game.settings.register("sfrpg", "useCustomChatCards", {
         name: "SFRPG.Settings.UseCustomChatCard.Name",
         hint: "SFRPG.Settings.UseCustomChatCard.Hint",
@@ -349,5 +340,23 @@ export const registerSystemSettings = function() {
                 }
             });
         }
+    });
+
+    game.settings.register("sfrpg", "notificationSchema", {
+        name: "SFRPG.Settings.NotificationSchema.Name",
+        hint: "SFRPG.Settings.NotificationSchema.Hint",
+        scope: "world",
+        config: true,
+        default: 0,
+        type: Number
+    });
+
+    game.settings.register("sfrpg", "worldSchemaVersion", {
+        name: "SFRPG.Settings.WorldSchemaVersion.Name",
+        hint: "SFRPG.Settings.WorldSchemaVersion.Hint",
+        scope: "world",
+        config: false,
+        default: 0,
+        type: Number
     });
 };

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -46,6 +46,7 @@ import { preloadHandlebarsTemplates, setupHandlebars } from "./module/handlebars
 import { ItemSFRPG } from "./module/item/item.js";
 import { ItemSheetSFRPG } from "./module/item/sheet.js";
 import migrateWorld from './module/migration.js';
+import { updateNotification } from './module/apps/update-notification';
 import SFRPGModifier from "./module/modifiers/modifier.js";
 import { SFRPGEffectType, SFRPGModifierType, SFRPGModifierTypes } from "./module/modifiers/types.js";
 import { RPC } from "./module/rpc.js";
@@ -686,6 +687,7 @@ Hooks.once("ready", async () => {
         connectToDocument(macro);
     }
 
+    // Migration system
     if (game.users.activeGM?.isSelf) {
         const currentSchema = game.settings.get('sfrpg', 'worldSchemaVersion') ?? 0;
         const systemSchema = Number(game.system.flags.sfrpg.schema);
@@ -714,6 +716,11 @@ Hooks.once("ready", async () => {
 
     }
 
+    // System Update Notifications
+    if (game.users.activeGM?.isSelf) {
+        updateNotification();
+    }
+
     Hooks.on("dropCanvasData", (canvas, data) => canvasHandler(canvas, data));
 
     const finishTime = (new Date()).getTime();
@@ -722,6 +729,13 @@ Hooks.once("ready", async () => {
     const startupDuration = finishTime - initTime;
     console.log(`Starfinder | [STARTUP] Total launch took ${Number(startupDuration / 1000).toFixed(2)} seconds.`);
 });
+
+/**
+ * Migrates containers from an old format (not sure what version) to a modern version.
+ * This should probably be removed at some point, since Data Model migration is preferable.
+ *
+ * @returns {[Promise]} An array of promises to resolve
+ */
 async function migrateOldContainers() {
     const promises = [];
     for (const actor of game.actors.contents) {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2156,6 +2156,11 @@
         "ModifiersMiscTabLabel": "Miscellaneous",
         "ModifiersPermanentTabLabel": "Permanent",
         "ModifiersTemporaryTabLabel": "Temporary",
+        "Notification": {
+            "Bugs": "<strong>Support & Issues</strong><p>For support, visit the <code>#sf1e</code> channel on the <a href=\"https://discord.com/invite/foundryvtt\">Foundry VTT Discord Server</a>. To view full change notes, file an issue, or contribute to development, please visit our <a href=\"https://github.com/foundryvtt-starfinder/foundryvtt-starfinder\">Github page</a>.</p>",
+            "Button": "Hide Until Next Update",
+            "Title": "System Update Information"
+        },
         "NPCSheet": {
             "Biography": {
                 "Organization": {
@@ -2538,6 +2543,10 @@
                 "ConfirmationTitle": "Lock Artwork Rotation Setting Change",
                 "Hint": "When enabled, enables Lock Artwork Rotation on character scale actors by default (Characters/NPC/Drones/Hazards). This can be overridden by the actor's prototype token settings.",
                 "Name": "Lock Artwork Rotation by Default"
+            },
+            "NotificationSchema": {
+                "Hint": "DON'T CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING.\nControls whether & which system update message(s) should be shown.",
+                "Name": "Update Notification Schema"
             },
             "SFRPGTheme": {
                 "Hint": "When enabled, a few minor tweaks to Foundry's colours will be made to match Starfinder's colour scheme.",


### PR DESCRIPTION
This adds the ability for the developers to include a message to users via a dialog box that displays upon first launch after the installation of a new system version. Messages can be added by adding a new entry to the `updateNotifications` object with a key that is 0.001 higher than the previous one.