### PR TITLE
Change notifications to client settings so users see them as well

### DIFF
--- a/src/module/apps/update-notification.js
+++ b/src/module/apps/update-notification.js
@@ -19,10 +19,13 @@ export async function updateNotification() {
 
     if (systemNotificationSchema > worldSchema) {
         // Get list of update versions and list of messages to display
-        const toDisplay = [];
-        for (const [schema, entry] of Object.entries(updateNotifications)) {
-            if (Number(schema) > worldSchema && Number(schema) <= systemNotificationSchema) {
-                toDisplay.push(entry);
+        // Only display the latest message if the user is new (schema setting at default of 0)
+        const toDisplay = worldSchema === 0 ? [updateNotifications[systemNotificationSchema]] : [];
+        if (worldSchema !== 0) {
+            for (const [schema, entry] of Object.entries(updateNotifications)) {
+                if (Number(schema) > worldSchema && Number(schema) <= systemNotificationSchema) {
+                    toDisplay.push(entry);
+                }
             }
         }
 

--- a/src/module/apps/update-notification.js
+++ b/src/module/apps/update-notification.js
@@ -1,6 +1,9 @@
 /**
  * A list of the notifications to display, as well as the system version associated with them.
- * `userType` has options "gm" or "all" to show to either just GMs or all users, respectively
+ *
+ * `version` should be a string containing the version number.
+ * `userType` has options "gm" or "all" to show to either just GMs or all users, respectively.
+ * `message` is the message to display. Supports html tags for formatting.
  */
 const updateNotifications = {
     0.001: {

--- a/src/module/apps/update-notification.js
+++ b/src/module/apps/update-notification.js
@@ -1,9 +1,11 @@
 /**
- * A list of the notifications to display, as well as the system version associated with them
+ * A list of the notifications to display, as well as the system version associated with them.
+ * `userType` has options "gm" or "all" to show to either just GMs or all users, respectively
  */
 const updateNotifications = {
     0.001: {
         version: "0.30.1",
+        userType: "all",
         message: "To facilitate better communication between the system developers and users, we have added this notification system, starting in Version 0.30.1, which will display upon installing a new system version with significant changes to be aware of. If an update is minor, you may not see one of these messages.<br>As they will only show up upon installing a new system version and we don't have the ability to wait for localization for all languages before releasing system updates, these messages will unfortunately only be in English (apologies to international users!)."
     }
 };
@@ -32,7 +34,9 @@ export async function updateNotification() {
         // Construct message
         let dlgText = "";
         for (const notif of toDisplay) {
-            dlgText += `<h4>Version ${notif.version}</h4><p>${notif.message}</p>`;
+            if (notif.userType === "all" || (notif.userType === "gm" && game.user.isGM)) {
+                dlgText += `<h4>Version ${notif.version}</h4><p>${notif.message}</p>`;
+            }
         }
         dlgText += game.i18n.localize("SFRPG.Notification.Bugs");
 

--- a/src/module/system/settings.js
+++ b/src/module/system/settings.js
@@ -345,7 +345,7 @@ export const registerSystemSettings = function() {
     game.settings.register("sfrpg", "notificationSchema", {
         name: "SFRPG.Settings.NotificationSchema.Name",
         hint: "SFRPG.Settings.NotificationSchema.Hint",
-        scope: "world",
+        scope: "user",
         config: true,
         default: 0,
         type: Number

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -716,10 +716,8 @@ Hooks.once("ready", async () => {
 
     }
 
-    // System Update Notifications
-    if (game.users.activeGM?.isSelf) {
-        updateNotification();
-    }
+    // System Update Information Notifications
+    updateNotification();
 
     Hooks.on("dropCanvasData", (canvas, data) => canvasHandler(canvas, data));
 


### PR DESCRIPTION
I'm debating whether it'd also be good to show these notifications to users as well, as sometimes it can be nice to emphasize things to users. This PR does 3 things:

1) changes the notification schema setting to `user` scope
2) Allows the specifying of whether an update message is for GMs only or for all users
3) Checks if the user is new (i.e. if the notification schema setting is the default `0` value), and only displays the latest update message if so