### PR TITLE
Avoid updating actor flags if in a compendium.

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -71,6 +71,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
      * Close all expanded item summaries for the current user.
      */
     async _closeAllItemSummaries() {
+        if (this.actor.compendium) return;
         for (const item of this.actor.items) {
             item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
         }
@@ -175,10 +176,13 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
 
         this._prepareItems(data);
 
-        for (const item of data.items) {
-            item.expanded = item.getFlag('sfrpg', `expanded.${game.user.id}`) || false;
-            if (item.expanded) {
-                await this._prepareItemSummary(item);
+        if (!this.actor.compendium)
+        {
+            for (const item of data.items) {
+                item.expanded = item.getFlag('sfrpg', `expanded.${game.user.id}`) || false;
+                if (item.expanded) {
+                    await this._prepareItemSummary(item);
+                }
             }
         }
 
@@ -1097,7 +1101,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             li.removeClass('expanded');
             item.expanded = false;
             summary.slideUp(200, () => {
-                item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
+                this.actor.compendium ?? item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
             });
         } else {
             const summary = await this._prepareItemSummary(item);
@@ -1105,7 +1109,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             li.addClass('expanded');
             item.expanded = true;
             summary.slideDown(200, () => {
-                item.setFlag('sfrpg', `expanded.${game.user.id}`, true);
+                this.actor.compendium ?? item.setFlag('sfrpg', `expanded.${game.user.id}`, true);
             });
         }
     }

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -71,7 +71,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
      * Close all expanded item summaries for the current user.
      */
     async _closeAllItemSummaries() {
-        if (this.actor.compendium) return;
+        if (this.actor.compendium || !this.actor.isOwner) return;
         for (const item of this.actor.items) {
             item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
         }
@@ -176,8 +176,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
 
         this._prepareItems(data);
 
-        if (!this.actor.compendium)
-        {
+        if (!this.actor.compendium && this.actor.isOwner) {
             for (const item of data.items) {
                 item.expanded = item.getFlag('sfrpg', `expanded.${game.user.id}`) || false;
                 if (item.expanded) {
@@ -1101,7 +1100,9 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             li.removeClass('expanded');
             item.expanded = false;
             summary.slideUp(200, () => {
-                this.actor.compendium ?? item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
+                if (this.actor.isOwner && !this.actor.compendium) {
+                    item.setFlag('sfrpg', `expanded.${game.user.id}`, false);
+                }
             });
         } else {
             const summary = await this._prepareItemSummary(item);
@@ -1109,7 +1110,9 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
             li.addClass('expanded');
             item.expanded = true;
             summary.slideDown(200, () => {
-                this.actor.compendium ?? item.setFlag('sfrpg', `expanded.${game.user.id}`, true);
+                if (this.actor.isOwner && !this.actor.compendium) {
+                    item.setFlag('sfrpg', `expanded.${game.user.id}`, true);
+                }
             });
         }
     }


### PR DESCRIPTION
When opening an actor, interacting with item summaries or closing an actor we should not edit the flags for persisting open/close state if the actor is in a compendium.