### PR TITLE
fix spellcasting ability selection

### DIFF
--- a/src/module/data/actor/base-actor.mjs
+++ b/src/module/data/actor/base-actor.mjs
@@ -221,6 +221,14 @@ export default class SFRPGActorBase extends SFRPGDocumentBase {
                 reflex: new fields.SchemaField(SFRPGActorBase._saveFieldData(), {label: "SFRPG.ReflexSave"}),
                 will: new fields.SchemaField(SFRPGActorBase._saveFieldData(), {label: "SFRPG.WillSave"})
             });
+            foundry.utils.mergeObject(schema.attributes.fields, {
+                spellcasting: new fields.StringField({
+                    initial: "",
+                    blank: true,
+                    choices: ["", ...Object.keys(CONFIG.SFRPG.abilities)],
+                    required: false
+                })
+            });
         }
         return schema;
     }

--- a/src/module/rules/actions/item/calculate-save-dc.js
+++ b/src/module/rules/actions/item/calculate-save-dc.js
@@ -22,10 +22,13 @@ export default function(engine) {
                 if (!dcFormula) {
                     const ownerKeyAbilityId = classes[0]?.system.kas ?? null;
                     const itemKeyAbilityId = data.ability;
+                    const spellPrepMode = data.preparation.mode;
                     const spellbookSpellAbility = actorData?.attributes.spellcasting;
                     const classSpellAbility = classes[0]?.system.spellAbility;
 
-                    const abilityKey = itemKeyAbilityId || spellbookSpellAbility || classSpellAbility || ownerKeyAbilityId;
+                    const abilityKey = itemKeyAbilityId
+                        || ((spellPrepMode === "innate" || spellPrepMode === "always") ? spellbookSpellAbility || classSpellAbility : classSpellAbility || spellbookSpellAbility)
+                        || ownerKeyAbilityId;
 
                     if (actor.type === "npc" || actor.type === "npc2") {
                         if (itemData.type === "spell") {


### PR DESCRIPTION
Fixes #1747 

Also implements what I presume to be the correct selection order for spellcasting ability DC selection;

For innate/always available spells:
Spell's specified ability -> Spellcasting Ability (from spellbook page) -> class Spellcasting Ability -> class Key Ability Score

For other spells (all normally prepared spells):
Spell's specified ability -> class Spellcasting Ability -> Spellcasting Ability (from spellbook page) -> class Key Ability Score