### PR TITLE
Fix drone ownership not saving

### DIFF
--- a/src/less/actors.less
+++ b/src/less/actors.less
@@ -40,7 +40,11 @@
 
             // For Drone owner name clickability
             li.drone-owner {
+                font-weight: bold;
                 span.drone-owner-name {
+                    font-family: "Exo 2";
+                    font-weight: normal;
+                    font-size: 12pt;
                     cursor: pointer;
                     &:hover {
                         text-shadow: 0 0 10px red;

--- a/src/less/actors.less
+++ b/src/less/actors.less
@@ -37,6 +37,16 @@
                 text-overflow: ellipsis;
                 overflow: hidden;
             }
+
+            // For Drone owner name clickability
+            li.drone-owner {
+                span.drone-owner-name {
+                    cursor: pointer;
+                    &:hover {
+                        text-shadow: 0 0 10px red;
+                    }
+                }
+            }
         }
 
         /* Header Summary Details */

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1298,7 +1298,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
     async _onDrop(event) {
         event.preventDefault();
 
-        const parsedDragData = TextEditor.getDragEventData(event);
+        const parsedDragData = foundry.applications.ux.TextEditor.getDragEventData(event);
         if (Hooks.call('dropActorSheetData', this.actor, this, parsedDragData) === false) {
             // Further processing halted
         } else if (parsedDragData.type === 'Item' || parsedDragData.type === 'ItemCollection') {

--- a/src/module/actor/sheet/drone.js
+++ b/src/module/actor/sheet/drone.js
@@ -28,6 +28,10 @@ export class ActorSheetSFRPGDrone extends ActorSheetSFRPG {
 
     async getData() {
         const sheetData = await super.getData();
+        if (sheetData.actor.system.details.owner) {
+            const owner = await fromUuid(sheetData.actor.system.details.owner);
+            sheetData.owner = owner ?? null;
+        }
 
         return sheetData;
     }
@@ -309,6 +313,24 @@ export class ActorSheetSFRPGDrone extends ActorSheetSFRPG {
         html.find(".modifier-edit").click(this._onModifierEdit.bind(this));
         html.find(".modifier-delete").click(this._onModifierDelete.bind(this));
         html.find(".modifier-toggle").click(this._onToggleModifierEnabled.bind(this));
+
+        html.find("span.drone-owner-name").on("click", (event) => this._onOwnerClick(event));
+        html.find("span.drone-owner-name").on("contextmenu", (event) => this._onOwnerRemove(event));
+    }
+
+    async _onOwnerClick(event) {
+        event.preventDefault();
+        const uuid = event.currentTarget.dataset.ownerUuid;
+        const actor = await fromUuid(uuid);
+
+        if (actor) {
+            actor.sheet.render(true);
+        }
+    }
+
+    async _onOwnerRemove(event) {
+        event.preventDefault();
+        await this.actor.update({"system.details.owner": null});
     }
 
     /**
@@ -336,5 +358,18 @@ export class ActorSheetSFRPGDrone extends ActorSheetSFRPG {
         event.preventDefault();
         await this._onSubmit(event);
         return this.actor.repairDrone();
+    }
+
+    /** @override */
+    async _onDrop(event) {
+        event.preventDefault();
+        const parsedDragData = foundry.applications.ux.TextEditor.getDragEventData(event);
+        if (Hooks.call('dropActorSheetData', this.actor, this, parsedDragData) === false) {
+            // Further processing halted
+        } else if (parsedDragData.type === "Actor") {
+            await this.actor.update({"system.details.owner": parsedDragData.uuid});
+        } else if (parsedDragData.type === "Item" || parsedDragData.type === 'ItemCollection') {
+            await this.processDroppedItems(event, parsedDragData);
+        }
     }
 }

--- a/src/module/data/actor/drone.mjs
+++ b/src/module/data/actor/drone.mjs
@@ -56,6 +56,13 @@ export default class SFRPGActorDrone extends SFRPGActorBase {
             })
         });
 
+        foundry.utils.mergeObject(schema.details.fields, {
+            owner: new fields.DocumentUUIDField({
+                initial: null,
+                nullable: true
+            })
+        });
+
         // Edit initial values as needed
         schema.skills.initial.acr.enabled = true;
         schema.skills.initial.ath.enabled = true;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -954,6 +954,7 @@
                     "Repair": "Repair"
                 },
                 "Defense": "Defense",
+                "DropToSetOwner": "Drop an actor here to set the drone's owner.<br>Click to open the owner's sheet, right-click to clear owner.",
                 "Owner": "Owner"
             },
             "Inventory": {

--- a/static/templates/actors/drone-sheet.hbs
+++ b/static/templates/actors/drone-sheet.hbs
@@ -27,7 +27,7 @@
             {{!-- Character Summary --}}
             <ul class="summary">
                 <li class="drone-owner" data-tooltip="SFRPG.DroneSheet.Header.DropToSetOwner">
-                    {{localize "SFRPG.DroneSheet.Header.Owner"}}: {{#if owner.name}}<span class="drone-owner-name" data-owner-uuid="{{owner._uuid}}">{{owner.name}}</span>{{else}}None{{/if}}
+                    {{localize "SFRPG.DroneSheet.Header.Owner"}} - {{#if owner.name}}<span class="drone-owner-name tag" data-owner-uuid="{{owner._uuid}}">{{owner.name}}</span>{{else}}None{{/if}}
                 </li>
             </ul>
 

--- a/static/templates/actors/drone-sheet.hbs
+++ b/static/templates/actors/drone-sheet.hbs
@@ -26,8 +26,8 @@
 
             {{!-- Character Summary --}}
             <ul class="summary">
-                <li>
-                    <input type="text" name="system.details.owner" value="{{system.details.owner}}" data-tooltip="<strong>{{localize "SFRPG.DroneSheet.Header.Owner"}}</strong><br>@details.owner" placeholder="{{localize "SFRPG.DroneSheet.Header.Owner"}}" />
+                <li class="drone-owner" data-tooltip="SFRPG.DroneSheet.Header.DropToSetOwner">
+                    {{localize "SFRPG.DroneSheet.Header.Owner"}}: {{#if owner.name}}<span class="drone-owner-name" data-owner-uuid="{{owner._uuid}}">{{owner.name}}</span>{{else}}None{{/if}}
                 </li>
             </ul>
 


### PR DESCRIPTION
Fixes drone ownership not saving by adding a UUID field for the drone's owner. Allows an actor to be dropped on the drone's sheet to set ownership, with click-to-open owner sheet functionality, and right-click to clear ownership.