### PR TITLE
Enricher fixes

### DIFF
--- a/changelist.md
+++ b/changelist.md
@@ -3,6 +3,7 @@ This update adds support for Foundry VTT Version 14, while addressing a couple o
 
 ## Breaking Changes
 - Starfinder's Compendium Art Mapping functionality has been removed in favor of Foundry's native compendium art map support.
+- Enriched description html for chat cards is now located at `description.enrichedShort` and `description.enrichedValue` instead of `description.short` and `description.value`, respectively
 
 ## Core System Improvements
 - Added support for Foundry v14
@@ -11,6 +12,7 @@ This update adds support for Foundry VTT Version 14, while addressing a couple o
 ## Bugfixes
 - Document expanded fields on sheets now stay open when combat state or turn is updated
 - The Spellcasting Ability field at the top of the spellbook page for characters and drones now works correctly
+- Inline links' and enrichers' dynamic formulas no longer break once sent to chat
 
 # Version 0.30.1
 This update contains a few small fixes that fix a couple of bugs with the new targeting system and chat cards, as well as introduces a method for us (the developers) to make announcements about new features and fixes to users.

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -442,7 +442,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
      */
     async _prepareItemSummary(item) {
         const chatData = await item.getChatData();
-        const desiredDescription = chatData.description.short || chatData.description.value;
+        const desiredDescription = chatData.description.enrichedShort || chatData.description.enrichedValue;
         const div = $(`<div class="item-summary">${desiredDescription}</div>`);
         const props = $(`<div class="item-properties"></div>`);
         chatData.chatProperties.forEach(p => {

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -760,12 +760,12 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
             const summary = li.children('.item-summary');
             summary.slideUp(200, () => summary.remove());
         } else {
-            const desiredDescription = await foundry.applications.ux.TextEditor.enrichHTML(content || chatData.description.value, {
+            const enrichedDescription = await foundry.applications.ux.TextEditor.enrichHTML(content || chatData.description.value, {
                 async: true,
                 rollData: this.actor.getRollData() ?? {},
                 secrets: this.actor.isOwner
             });
-            const div = $(`<div class="item-summary">${desiredDescription}</div>`);
+            const div = $(`<div class="item-summary">${enrichedDescription}</div>`);
             Hooks.callAll("renderItemSummary", this, div, {});
 
             li.append(div.hide());

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -197,7 +197,7 @@ export class ItemCollectionSheet extends DocumentSheet {
             const summary = li.children('.item-summary');
             summary.slideUp(200, () => summary.remove());
         } else {
-            const div = $(`<div class="item-summary">${chatData.system.description.value}</div>`);
+            const div = $(`<div class="item-summary">${chatData.system.description.enrichedValue}</div>`);
             Hooks.callAll("renderItemSummary", this, div, {}); // Event listeners need to be added to newly added HTML.
             const props = $(`<div class="item-properties"></div>`);
             chatData.chatProperties.forEach(p => props.append(`<span class="tag" ${ p.tooltip ? ("data-tooltip='" + p.tooltip + "'") : ""}>${p.name}</span>`));
@@ -288,7 +288,7 @@ export class ItemCollectionSheet extends DocumentSheet {
         htmlOptions.rollData ||= (this.actor.getRollData() ?? {});
 
         // Rich text description
-        data.system.description.value = await foundry.applications.ux.TextEditor.enrichHTML(data.system.description.value, htmlOptions);
+        data.system.description.enrichedValue = await foundry.applications.ux.TextEditor.enrichHTML(data.system.description.value, htmlOptions);
 
         // Item type specific properties
         const props = [];

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -413,10 +413,10 @@ export class ItemSFRPG extends Mix(foundry.documents.Item).with(ItemActivationMi
                     }
                 }
 
-                if (templateData.system.description.short) {
-                    templateData.system.description.short = descriptionText;
+                if (templateData.system.description.enrichedShort) {
+                    templateData.system.description.enrichedShort = descriptionText;
                 } else {
-                    templateData.system.description.value = descriptionText;
+                    templateData.system.description.enrichedValue = descriptionText;
                 }
             }
         }
@@ -468,12 +468,12 @@ export class ItemSFRPG extends Mix(foundry.documents.Item).with(ItemActivationMi
         const rollData = RollContext.createItemRollContext(this, this.actor).getRollData();
 
         // Rich text description
-        if (data.description.short) data.description.short = await foundry.applications.ux.TextEditor.enrichHTML(data.description.short, {
+        if (data.description.short) data.description.enrichedShort = await foundry.applications.ux.TextEditor.enrichHTML(data.description.short, {
             async,
             secrets,
             rollData
         });
-        data.description.value = await foundry.applications.ux.TextEditor.enrichHTML(data.description.value, {
+        data.description.enrichedValue = await foundry.applications.ux.TextEditor.enrichHTML(data.description.value, {
             async,
             secrets,
             rollData

--- a/src/module/system/enrichers/check.js
+++ b/src/module/system/enrichers/check.js
@@ -149,7 +149,7 @@ export default class CheckEnricher extends BaseEnricher {
 
         // Disambiguate between "INTelligence and INTimidate", then select skill/save/ability
         if (id === "int") data.type === "intimidate" ? actor.rollSkill(id, options) : actor.rollAbility(id, options);
-        else if      (id in CONFIG.SFRPG.skills)    actor.rollSkill(id, options);
+        else if (id in CONFIG.SFRPG.skills)    actor.rollSkill(id, options);
         else if (id in CONFIG.SFRPG.saves)     actor.rollSave(id, options);
         else if (id in CONFIG.SFRPG.abilities) actor.rollAbility(id, options);
 

--- a/static/templates/chat/consumable-card.hbs
+++ b/static/templates/chat/consumable-card.hbs
@@ -4,7 +4,7 @@
         <h3 class="item-name noborder">{{item.name}}</h3>
     </header>
 
-    <div class="card-content">{{{system.description.value}}}</div>
+    <div class="card-content">{{{system.description.enrichedValue}}}</div>
 
     <div class="card-buttons flexcol">
         {{#if system.hasCharges}}

--- a/static/templates/chat/consumed-item-card.hbs
+++ b/static/templates/chat/consumed-item-card.hbs
@@ -5,11 +5,11 @@
     </header>
 
     <div class="card-content">
-        {{#if (or system.description.value system.description.short)}}
-            {{#if system.description.short}}
-                {{{system.description.short}}}
+        {{#if (or system.description.enrichedValue system.description.enrichedShort)}}
+            {{#if system.description.enrichedShort}}
+                {{{system.description.enrichedShort}}}
             {{else}}
-                {{{system.description.value}}}
+                {{{system.description.enrichedValue}}}
             {{/if}}
         {{/if}}
     </div>

--- a/static/templates/chat/item-action-card.hbs
+++ b/static/templates/chat/item-action-card.hbs
@@ -8,10 +8,10 @@
     </header>
 
     <div class="card-content">
-        {{#if item.system.description.short}}
-        {{{item.system.description.short}}}
+        {{#if item.system.description.enrichedShort}}
+        {{{item.system.description.enrichedShort}}}
         {{else}}
-        {{{item.system.description.value}}}
+        {{{item.system.description.enrichedValue}}}
         {{/if}}
     </div>
 

--- a/static/templates/chat/item-card.hbs
+++ b/static/templates/chat/item-card.hbs
@@ -5,12 +5,12 @@
     </header>
 
     <div class="card-content">
-        {{#if system.description.short}}
-            {{{system.description.short}}}
+        {{#if system.description.enrichedShort}}
+            {{{system.description.enrichedShort}}}
         {{else}}
-            {{{system.description.value}}}
+            {{{system.description.enrichedValue}}}
         {{/if}}
-        {{#if system.materials.value}}
+        {{#if system.materials.enrichedValue}}
         <p><strong>{{ localize "SFRPG.Items.Spell.SpellcastingMaterials" }}:</strong> {{system.materials.value}}</p>
         {{/if}}
     </div>

--- a/static/templates/chat/weapon-card.hbs
+++ b/static/templates/chat/weapon-card.hbs
@@ -4,7 +4,7 @@
         <h3 class="item-name noborder">{{item.name}}</h3>
     </header>
 
-    <div class="card-content">{{{system.description.value}}}</div>
+    <div class="card-content">{{{system.description.enrichedValue}}}</div>
 
     <div class="card-buttons flexcol">
         <button type="button" data-action="weaponAttack">Attack</button>


### PR DESCRIPTION
Fixes an untracked issue where dynamically calculated links were getting stuck as static values after an item was sent to chat.

Caused by fixes made when `deepClone()` was no longer allowed to be used on the `system` property directly.