### PR TITLE
Fix namespacing of utility functions to fix broken selector apps

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -708,7 +708,7 @@ export class ActorSheetSFRPG extends foundry.appv1.sheets.ActorSheet {
 
         let options = null;
         if (this.actor.system.options) {
-            options = duplicate(this.actor.system.options);
+            options = foundry.utils.duplicate(this.actor.system.options);
         }
         if (!options) {
             options = new Map();

--- a/src/module/apps/trait-selector.js
+++ b/src/module/apps/trait-selector.js
@@ -24,7 +24,7 @@ export class TraitSelectorSFRPG extends FormApplication {
      */
     getData() {
         const dataLocation = this.options.location;
-        const traitData = getProperty(this.object, dataLocation);
+        const traitData = foundry.utils.getProperty(this.object, dataLocation);
         return this._getTraitChoices(traitData);
     }
 

--- a/src/module/apps/trait-selectors/actor-trait-selector.js
+++ b/src/module/apps/trait-selectors/actor-trait-selector.js
@@ -20,7 +20,7 @@ export class ActorTraitSelectorSFRPG extends TraitSelectorSFRPG {
     _getTraitChoices(traitData) {
 
         // create the array of choices
-        const choices = duplicate(this.options.choices);
+        const choices = foundry.utils.duplicate(this.options.choices);
         // console.log(this, choices, traitData);
 
         // define options that can't be chosen

--- a/src/module/apps/trait-selectors/weapon-property-selector.js
+++ b/src/module/apps/trait-selectors/weapon-property-selector.js
@@ -20,7 +20,7 @@ export class WeaponPropertySelectorSFRPG extends TraitSelectorSFRPG {
     _getTraitChoices(traitData) {
 
         // create the array of choices
-        const choices = duplicate(this.options.choices);
+        const choices = foundry.utils.duplicate(this.options.choices);
         // console.log(this, choices, traitData);
 
         for (const [key, displayName] of Object.entries(choices)) {


### PR DESCRIPTION
Fixes namespacing on a couple of utility functions within the trait selector app files. These errors prevented them from opening correctly.