### PR TITLE
Remove GM-Only designation from GM Notes field

### DIFF
--- a/static/system.json
+++ b/static/system.json
@@ -323,9 +323,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "ammunition": {
@@ -335,9 +332,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "archetypes": {
@@ -347,10 +341,7 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
-        ]
+                  ]
       },
       "asi": {
         "htmlFields": [
@@ -359,9 +350,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "augmentation": {
@@ -371,9 +359,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "chassis": {
@@ -383,9 +368,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "class": {
@@ -395,9 +377,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "consumable": {
@@ -407,9 +386,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "container": {
@@ -419,9 +395,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "effect": {
@@ -431,9 +404,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "equipment": {
@@ -443,9 +413,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "feat": {
@@ -455,9 +422,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "fusion": {
@@ -467,9 +431,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "goods": {
@@ -479,9 +440,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "hybrid": {
@@ -491,9 +449,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "magic": {
@@ -503,9 +458,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "mod": {
@@ -515,9 +467,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "race": {
@@ -527,9 +476,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "shield": {
@@ -539,9 +485,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "spell": {
@@ -551,9 +494,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipAblativeArmor": {
@@ -563,9 +503,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipAction": {
@@ -575,9 +512,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipArmor": {
@@ -587,9 +521,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipComputer": {
@@ -599,9 +530,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipCrewQuarter": {
@@ -611,9 +539,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipDefensiveCountermeasure": {
@@ -623,9 +548,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipDriftEngine": {
@@ -635,9 +557,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipExpansionBay": {
@@ -647,9 +566,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipFortifiedHull": {
@@ -659,9 +575,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipFrame": {
@@ -671,9 +584,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipOtherSystem": {
@@ -683,9 +593,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipPowerCore": {
@@ -695,9 +602,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipReinforcedBulkhead": {
@@ -707,9 +611,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipSecuritySystem": {
@@ -719,9 +620,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipSensor": {
@@ -731,9 +629,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipShield": {
@@ -743,9 +638,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipSpecialAbility": {
@@ -755,9 +647,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipThruster": {
@@ -767,9 +656,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "starshipWeapon": {
@@ -779,9 +665,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "technological": {
@@ -791,9 +674,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "theme": {
@@ -803,9 +683,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "upgrade": {
@@ -815,9 +692,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "vehicleAttack": {
@@ -827,9 +701,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "vehicleSystem": {
@@ -839,9 +710,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "weapon": {
@@ -851,9 +719,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       },
       "weaponAccessory": {
@@ -863,9 +728,6 @@
           "description.chat",
           "description.short",
           "description.unidentified"
-        ],
-        "gmOnlyFields": [
-          "description.gmNotes"
         ]
       }
     }


### PR DESCRIPTION
Patches around a core Foundry bug that prevents players from creating items that have any data fields designated as `gmOnly`. This issue was apparently addressed in 14.361, but is still showing up in 14.363 (see [this core issue](https://github.com/foundryvtt/foundryvtt/issues/14252) and [comment](https://github.com/foundryvtt/foundryvtt/issues/14252#issuecomment-4651350231)).