### PR TITLE
Temporary Effects returned in appliedEffects

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -38,7 +38,7 @@ export class ActorSFRPG extends Mix(foundry.documents.Actor).with(ActorCondition
         super(data, context);
     }
 
-    // appliedEffects effects can be displayed on the token, so hijack it and include effects
+    // appliedEffects effects can be displayed on the token, so hijack it and include shown effects
     get appliedEffects() {
         const fromEffects = this.items
             .filter((e) => e.type === "effect" && e.system.showOnToken && e.system.enabled)
@@ -48,6 +48,7 @@ export class ActorSFRPG extends Mix(foundry.documents.Actor).with(ActorCondition
     }
 
     // Temporary effects are displayed on the token, so hijack it and include effects
+    // This is no longer called in Foundry V14 but the code is still present so we'll keep it here for now in case they call it again.
     get temporaryEffects() {
         const fromEffects = this.items
             .filter((e) => e.type === "effect" && e.system.showOnToken && e.system.enabled)

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -38,6 +38,15 @@ export class ActorSFRPG extends Mix(foundry.documents.Actor).with(ActorCondition
         super(data, context);
     }
 
+    // appliedEffects effects can be displayed on the token, so hijack it and include effects
+    get appliedEffects() {
+        const fromEffects = this.items
+            .filter((e) => e.type === "effect" && e.system.showOnToken && e.system.enabled)
+            .map((e) => new TokenEffect(e));
+
+        return [...super.appliedEffects, ...fromEffects];
+    }
+
     // Temporary effects are displayed on the token, so hijack it and include effects
     get temporaryEffects() {
         const fromEffects = this.items

--- a/src/module/token/token-effect.js
+++ b/src/module/token/token-effect.js
@@ -16,6 +16,12 @@ export class TokenEffect {
         return this.#effect.parent;
     }
 
+    /**
+     * In Foundry V14 Compared to CONST ACTIVE_EFFECT_SHOW_ICON
+     * The icon is never shown. NEVER: 0,
+     * The icon is showed if the ActiveEffect has a temporary duration. CONDITIONAL: 1,
+     * The icon is always shown. ALWAYS: 2
+     */
     get showIcon() {
         return this.#effect.system.showOnToken ? 1 : 0;
     }

--- a/src/module/token/token-effect.js
+++ b/src/module/token/token-effect.js
@@ -16,6 +16,10 @@ export class TokenEffect {
         return this.#effect.parent;
     }
 
+    get showIcon() {
+        return this.#effect.system.showOnToken ? 1 : 0;
+    }
+
     get name() {
         return this.#effect.name;
     }


### PR DESCRIPTION
When foundry pulls back the effects it no longer uses temporaryEffects it uses appliedEffects now and checks for the showIcon condition.